### PR TITLE
토큰검증, 초기유저확인, 토큰재발급 관련 버그 픽스

### DIFF
--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -1,0 +1,15 @@
+import { Slot } from "expo-router";
+import IsNewUserProvider from "@/src/contexts/IsNewUserProvider";
+
+/**
+ * @description ContextProvider들로 감싸는 레이아웃
+ */
+function ContextLayout() {
+  return (
+    <IsNewUserProvider>
+      <Slot />
+    </IsNewUserProvider>
+  );
+}
+
+export default ContextLayout;

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -9,14 +9,13 @@ import styled, { ThemeProvider } from "styled-components/native";
 import { theme } from "@/src/constants/theme";
 import queryClient from "@/src/libs/queryClient";
 import initializeApp from "@/src/utils/initializeApp";
-import IsNewUserProvider from "@/src/contexts/IsNewUserProvider";
 
 SplashScreen.preventAutoHideAsync();
 
 /**
- * @description 필요한 Provider들을 제공하는 레이아웃
+ * @description 폰트 로딩, 라이브러리 provider, 공용 스타일 컴포넌트로 감싸는 레이아웃
  */
-function ProviderLayout() {
+function RootLayout() {
   useReactQueryDevTools(queryClient);
   const [isReady, setIsReady] = useState<boolean>(false);
   const pathname = usePathname();
@@ -40,14 +39,12 @@ function ProviderLayout() {
   return (
     <ThemeProvider theme={theme}>
       <QueryClientProvider client={queryClient}>
-        <IsNewUserProvider>
-          <ColorView pathname={pathname} onLayout={onLayoutRootView}>
-            <SafeLayout>
-              <StatusBar />
-              <Slot />
-            </SafeLayout>
-          </ColorView>
-        </IsNewUserProvider>
+        <ColorView pathname={pathname} onLayout={onLayoutRootView}>
+          <SafeView>
+            <StatusBar />
+            <Slot />
+          </SafeView>
+        </ColorView>
       </QueryClientProvider>
     </ThemeProvider>
   );
@@ -58,8 +55,8 @@ const ColorView = styled.View<{ pathname: string }>`
   background-color: ${({ pathname }) => (pathname === "/login" ? "#f0f5f8" : "#ffffff")};
 `;
 
-const SafeLayout = styled(SafeAreaView)`
+const SafeView = styled(SafeAreaView)`
   flex: 1;
 `;
 
-export default ProviderLayout;
+export default RootLayout;


### PR DESCRIPTION
# 개요

- `IsNewUserProvider`와 `LoginPage` 간 충돌 발생하며 런타임 에러(무한 로딩) 발생
    - [Error: Attempted to navigate before mounting the Root Layout component. Ensure the Root Layout component is rendering a Slot, or other navigator on the first render.]
- 토큰 재발급 도중 발생하는 에러는 `reject`와 함께 **router 처리와 토큰 삭제**가 필요
    - (기존에는 초기 접속에서 테스트를 해서 error 발생 시 `Redirect` 컴포넌트로 해결했지만, 만약 앱 내에서 특정 API 호출에 의해 재발급 도중 에러가 발생하면 login으로 던지기 위해 중복 예외 처리가 필요해지기 때문)

---

## 구현

- [X] `(app)`디렉토리 내에 `ProviderLayout`을 두고, 밖에는 `RootLayout`으로 이름 변경
- [X] `IsNewUserProvider`를 `ProviderLayout`에서 제공해 login 페이지에는 제공하지 않도록 수정
- [X] `interceptors`에서 **router 처리와 토큰 삭제**가 필요한 부분 추가하고, `axiosInstance` 대신 `axios`를 사용해 무한 로딩 해결

---

## 테스트 범위

- 모든 토큰이 없는 경우 -> OK
- 잘못된 access token과 제대로 된 refresh token을 가진 경우 -> OK
- 잘못된 access token과 refresh token을 가진 경우 -> OK

---