### PR TITLE
사용자 설정 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@dev-plugins/react-query": "^0.1.0",
     "@expo/vector-icons": "^14.0.2",
+    "@react-native-community/datetimepicker": "8.2.0",
     "@react-native-google-signin/google-signin": "^13.1.0",
     "@react-native-seoul/kakao-login": "^5.4.1",
     "@react-navigation/bottom-tabs": "^7.2.0",
@@ -46,6 +47,7 @@
     "react-native-calendars": "^1.1308.1",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-mmkv": "^3.2.0",
+    "react-native-modal-datetime-picker": "^18.0.0",
     "react-native-reanimated": "~3.16.1",
     "react-native-reanimated-carousel": "canary",
     "react-native-safe-area-context": "4.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@expo/vector-icons':
         specifier: ^14.0.2
         version: 14.0.4
+      '@react-native-community/datetimepicker':
+        specifier: 8.2.0
+        version: 8.2.0(expo@52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
       '@react-native-google-signin/google-signin':
         specifier: ^13.1.0
         version: 13.1.0(expo@52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
@@ -106,6 +109,9 @@ importers:
       react-native-mmkv:
         specifier: ^3.2.0
         version: 3.2.0(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      react-native-modal-datetime-picker:
+        specifier: ^18.0.0
+        version: 18.0.0(@react-native-community/datetimepicker@8.2.0(expo@52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))
       react-native-reanimated:
         specifier: ~3.16.1
         version: 3.16.7(@babel/core@7.26.0)(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
@@ -1161,6 +1167,19 @@ packages:
     resolution: {integrity: sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==}
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
+
+  '@react-native-community/datetimepicker@8.2.0':
+    resolution: {integrity: sha512-qrUPhiBvKGuG9Y+vOqsc56RPFcHa1SU2qbAMT0hfGkoFIj3FodE0VuPVrEa8fgy7kcD5NQmkZIKgHOBLV0+hWg==}
+    peerDependencies:
+      expo: '>=50.0.0'
+      react: '*'
+      react-native: '*'
+      react-native-windows: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      react-native-windows:
+        optional: true
 
   '@react-native-google-signin/google-signin@13.1.0':
     resolution: {integrity: sha512-C2/sqb0/s0c+Dwc/mykASZsRuHxGqn7SFrCxCY9D8p8IOQO05haInhCc7lzraJshRixGva5c/4usQZ71HMYSEQ==}
@@ -4334,6 +4353,12 @@ packages:
       react: '*'
       react-native: '*'
 
+  react-native-modal-datetime-picker@18.0.0:
+    resolution: {integrity: sha512-0jdvhhraZQlRACwr7pM6vmZ2kxgzJ4CpnmV6J3TVA6MrXMXK6Zo/upRBKkRp0+fTOiKuNblzesA2U59rYo6SGA==}
+    peerDependencies:
+      '@react-native-community/datetimepicker': '>=6.7.0'
+      react-native: '>=0.65.0'
+
   react-native-reanimated-carousel@4.0.0-canary.22:
     resolution: {integrity: sha512-GOTSXVuoV08ZUxGPuzQ1Kl1YOOOrKWb18uRlPsa759bFyiqFWpjjLrCUdfgBgF9ZqUHUbb1jj+UffFf2eGDz+A==}
     peerDependencies:
@@ -6917,6 +6942,14 @@ snapshots:
       '@babel/runtime': 7.26.0
       '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
       react: 18.3.1
+
+  '@react-native-community/datetimepicker@8.2.0(expo@52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      invariant: 2.2.4
+      react: 18.3.1
+      react-native: 0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)
+    optionalDependencies:
+      expo: 52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
 
   '@react-native-google-signin/google-signin@13.1.0(expo@52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -10872,6 +10905,12 @@ snapshots:
   react-native-mmkv@3.2.0(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
+      react-native: 0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)
+
+  react-native-modal-datetime-picker@18.0.0(@react-native-community/datetimepicker@8.2.0(expo@52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)):
+    dependencies:
+      '@react-native-community/datetimepicker': 8.2.0(expo@52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      prop-types: 15.8.1
       react-native: 0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)
 
   react-native-reanimated-carousel@4.0.0-canary.22(react-native-gesture-handler@2.20.2(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native-reanimated@3.16.7(@babel/core@7.26.0)(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):

--- a/src/apis/loginApi.ts
+++ b/src/apis/loginApi.ts
@@ -2,6 +2,7 @@ import { login } from "@react-native-seoul/kakao-login";
 import { GoogleSignin } from "@react-native-google-signin/google-signin";
 import axiosInstance from "../libs/axiosInstance";
 import endpoint from "../constants/endpoint";
+import { SuccessResponse } from "@/src/types/commonTypes";
 import { LoginType } from "@/src/types/loginTypes";
 
 GoogleSignin.configure({
@@ -22,5 +23,10 @@ export const googleLoginFn = async () => {
 export const kakaoLoginFn = async () => {
   const { accessToken } = await login();
   const { data } = await axiosInstance.post<LoginType>(endpoint.auth.kakao, { accessToken });
+  return data;
+};
+
+export const logoutFn = async () => {
+  const { data } = await axiosInstance.post<SuccessResponse>(endpoint.auth.logout);
   return data;
 };

--- a/src/apis/settingApi.ts
+++ b/src/apis/settingApi.ts
@@ -14,7 +14,16 @@ export const checkNewUserFn = async () => {
 };
 
 export const getUserSettingFn = async () => {
-  const { data } = await axiosInstance.get<UserSettingResult>(endpoint.setting.getSetting);
+  const { data } = await axiosInstance.get<UserSettingResult>(endpoint.setting.setting);
   console.log(data);
+  return data;
+};
+
+export const putUserSettingFn = async (variable: {
+  sleepTime: string;
+  notificationTime: string;
+  notificationSummary: boolean;
+}) => {
+  const { data } = await axiosInstance.put<UserSettingResult>(endpoint.setting.setting, variable);
   return data;
 };

--- a/src/apis/settingApi.ts
+++ b/src/apis/settingApi.ts
@@ -1,6 +1,6 @@
 import endpoint from "@/src/constants/endpoint";
 import axiosInstance from "@/src/libs/axiosInstance";
-import { CheckNewUserType, RegisterSettingType } from "@/src/types/settingTypes";
+import { CheckNewUserType, RegisterSettingType, UserSettingResult } from "@/src/types/settingTypes";
 
 export const registerSettingFn = async () => {
   const { data } = await axiosInstance.post<RegisterSettingType>(endpoint.setting.register);
@@ -9,6 +9,12 @@ export const registerSettingFn = async () => {
 
 export const checkNewUserFn = async () => {
   const { data } = await axiosInstance.get<CheckNewUserType>(endpoint.setting.checkNew);
+  console.log(data);
+  return data;
+};
+
+export const getUserSettingFn = async () => {
+  const { data } = await axiosInstance.get<UserSettingResult>(endpoint.setting.getSetting);
   console.log(data);
   return data;
 };

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -1,4 +1,4 @@
-import { Slot } from "expo-router";
+import { Stack } from "expo-router";
 import IsNewUserProvider from "@/src/contexts/IsNewUserProvider";
 
 /**
@@ -7,7 +7,7 @@ import IsNewUserProvider from "@/src/contexts/IsNewUserProvider";
 function ContextLayout() {
   return (
     <IsNewUserProvider>
-      <Slot />
+      <Stack screenOptions={{ headerShown: false }} />
     </IsNewUserProvider>
   );
 }

--- a/src/app/(app)/setting.tsx
+++ b/src/app/(app)/setting.tsx
@@ -1,0 +1,10 @@
+import SettingPage from "@/src/pages/Setting";
+
+/**
+ * @description 유저 설정 페이지 라우터
+ */
+function SettingRouter(): JSX.Element {
+  return <SettingPage />;
+}
+
+export default SettingRouter;

--- a/src/app/(app)/setting.tsx
+++ b/src/app/(app)/setting.tsx
@@ -1,10 +1,30 @@
+import { getUserSettingFn } from "@/src/apis/settingApi";
+import CommonError from "@/src/components/ui/CommonError";
+import Loading from "@/src/components/ui/Loading";
 import SettingPage from "@/src/pages/Setting";
+import { useQuery } from "@tanstack/react-query";
 
 /**
  * @description 유저 설정 페이지 라우터
  */
 function SettingRouter(): JSX.Element {
-  return <SettingPage />;
+  const { isPending, isError, data, refetch } = useQuery({
+    queryFn: getUserSettingFn,
+    queryKey: ["user-setting"],
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (isPending) {
+    return <Loading />;
+  }
+
+  if (isError) {
+    return (
+      <CommonError titleText="사용자 설정 로딩 에러" buttonText="다시 로딩하기" onPress={refetch} />
+    );
+  }
+
+  return <SettingPage data={data} />;
 }
 
 export default SettingRouter;

--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -10,7 +10,7 @@ const endpoint = {
   setting: {
     checkNew: "/api/v1/user-settings/check-new",
     register: "/api/v1/user-settings/register",
-    getSetting: "/api/v1/user-settings",
+    setting: "/api/v1/user-settings",
   },
   thread: {
     chat: "/api/v1/chats",

--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -10,6 +10,7 @@ const endpoint = {
   setting: {
     checkNew: "/api/v1/user-settings/check-new",
     register: "/api/v1/user-settings/register",
+    getSetting: "/api/v1/user-settings",
   },
   thread: {
     chat: "/api/v1/chats",

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -52,6 +52,9 @@ const colors = {
   calendarIcon: "#424242",
   calendarRed: "#FF5656",
   calendarBlue: "#4766FF",
+  settingText: "#121212",
+  settingSubText: "#AAAAAA",
+  settingValueText: "#505050",
 };
 
 const gap = {
@@ -59,6 +62,7 @@ const gap = {
   base: responsiveToPx("8px"),
   md: responsiveToPx("12px"),
   lg: responsiveToPx("24px"),
+  xxl: responsiveToPx("50px"),
 };
 
 export const theme: DefaultTheme = {

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,24 @@
+import { useMutation } from "@tanstack/react-query";
+import { logoutFn } from "@/src/apis/loginApi";
+import { removeSecureValue } from "@/src/libs/secureStorage";
+import { removeStorageValue } from "@/src/libs/mmkv";
+import { router } from "expo-router";
+
+const useLogout = () => {
+  return useMutation({
+    mutationFn: logoutFn,
+    onSuccess: async (data) => {
+      // Todo: 로그아웃 성공 Toast message 추가
+      console.log(data);
+      await removeSecureValue("refreshToken");
+      removeStorageValue("accessToken");
+      router.replace("/login");
+    },
+    onError: (error) => {
+      console.error(error.response?.data);
+      // Todo: 로그아웃 실패 Toast message 추가
+    },
+  });
+};
+
+export default useLogout;

--- a/src/hooks/useUpdateSetting.ts
+++ b/src/hooks/useUpdateSetting.ts
@@ -1,0 +1,27 @@
+import { putUserSettingFn } from "@/src/apis/settingApi";
+import { UserSettingResult } from "@/src/types/settingTypes";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const useUpdateSetting = (data: UserSettingResult) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: putUserSettingFn,
+    onMutate: (variable) => {
+      // 여기서의 variable 객체는 mutationFn에게 전달된 variable에 해당!
+      // 즉 여기서 낙관적 업데이트
+      queryClient.setQueryData(["user-setting"], { ...data, result: variable });
+    },
+    onSuccess: (data) => {
+      console.log("성공", data);
+    },
+    onError: (error) => {
+      console.error(error.response?.data);
+      // 요청에 실패했으므로 서버에서 값 가져와 롤백
+      queryClient.invalidateQueries({ queryKey: ["user-setting"] });
+      // Todo: 토스트 메시지로 에러 원인 알려주기
+    },
+  });
+};
+
+export default useUpdateSetting;

--- a/src/libs/secureStorage.ts
+++ b/src/libs/secureStorage.ts
@@ -21,6 +21,7 @@ export const getSecureValue = async (key: string): Promise<string | null> => {
 export const removeSecureValue = async (key: string): Promise<void> => {
   try {
     await SecureStore.deleteItemAsync(key);
+    console.log("secureStore에서 ", key, "삭제 성공");
   } catch (e) {
     console.error("secureStore에서", key, "삭제 실패", e);
   }

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -5,6 +5,7 @@ import DayComponent from "./DayComponent";
 import ChatButton from "./ChatButton";
 import { theme } from "@/src/constants/theme";
 import * as S from "./styles";
+import { useRouter } from "expo-router";
 
 LocaleConfig.locales["ko"] = {
   monthNames: [
@@ -29,6 +30,7 @@ LocaleConfig.locales["ko"] = {
 LocaleConfig.defaultLocale = "ko";
 
 function CalendarPage(): JSX.Element {
+  const router = useRouter();
   const { diariesData, changeDate } = useCurrentDate();
 
   const handleCopyPress = () => {
@@ -36,7 +38,7 @@ function CalendarPage(): JSX.Element {
   };
 
   const handleSettingPress = () => {
-    console.log("setting button");
+    router.push("/(app)/setting");
   };
 
   const handleDayPress = (day: DateData) => {

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "expo-router";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { UserSettingResult } from "@/src/types/settingTypes";
+import useUpdateSetting from "@/src/hooks/useUpdateSetting";
 import { theme } from "@/src/constants/theme";
 import * as S from "./styles";
 
@@ -11,10 +12,19 @@ interface Props {
 }
 
 function SettingPage({ data }: Props): JSX.Element {
+  const { sleepTime, notificationSummary, notificationTime } = data.result;
   const router = useRouter();
+  const { mutate } = useUpdateSetting(data);
 
   const handlePrevButton = () => {
     router.back();
+  };
+
+  const handleNotificationSummary = () => {
+    mutate({
+      ...data.result,
+      notificationSummary: !notificationSummary,
+    });
   };
 
   return (
@@ -35,14 +45,14 @@ function SettingPage({ data }: Props): JSX.Element {
               <S.ItemTitleText>자는 시간 설정</S.ItemTitleText>
               <S.ItemDescriptionText>해당 시간에 대화를 초기화 해드려요</S.ItemDescriptionText>
             </S.ItemTitleBox>
-            <S.ItemValueText>{data.result.sleepTime}</S.ItemValueText>
+            <S.ItemValueText>{sleepTime}</S.ItemValueText>
           </S.ItemButton>
           <S.ItemButton disabled={true}>
             <S.ItemTitleBox>
               <S.ItemTitleText>푸시 알림</S.ItemTitleText>
               <S.ItemDescriptionText>푸시 알림을 허용/차단할 수 있어요</S.ItemDescriptionText>
             </S.ItemTitleBox>
-            <Switch value={data.result.notificationSummary} />
+            <Switch value={notificationSummary} onChange={handleNotificationSummary} />
           </S.ItemButton>
           <S.ItemButton hitSlop={10}>
             <S.ItemTitleBox>
@@ -50,7 +60,7 @@ function SettingPage({ data }: Props): JSX.Element {
               <S.ItemDescriptionText>원하는 시간에 대화할 수 있도록</S.ItemDescriptionText>
               <S.ItemDescriptionText>앱 푸시 알림을 보내드려요</S.ItemDescriptionText>
             </S.ItemTitleBox>
-            <S.ItemValueText>{data.result.notificationTime}</S.ItemValueText>
+            <S.ItemValueText>{notificationTime}</S.ItemValueText>
           </S.ItemButton>
           <S.ItemButton hitSlop={10}>
             <S.ItemTitleBox>

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import { ScrollView, Switch } from "react-native";
 import { useRouter } from "expo-router";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import Ionicons from "@expo/vector-icons/Ionicons";
+import DateTimePickerModal from "react-native-modal-datetime-picker";
 import Loading from "@/src/components/ui/Loading";
 import useUpdateSetting from "@/src/hooks/useUpdateSetting";
 import useLogout from "@/src/hooks/useLogout";
@@ -15,9 +17,40 @@ interface Props {
 
 function SettingPage({ data }: Props): JSX.Element {
   const { sleepTime, notificationSummary, notificationTime } = data.result;
+
+  const [isDatePickerVisible, setIsDatePickerVisible] = useState<boolean>(false);
+  const [datePickerType, setDatePickerType] = useState<"sleepTime" | "notificationTime" | null>(
+    null
+  );
+
   const router = useRouter();
   const { mutate: settingMutate } = useUpdateSetting(data);
   const { isPending, mutate: logoutMutate } = useLogout();
+
+  const showDatePicker = (datePickerType: "sleepTime" | "notificationTime") => {
+    setIsDatePickerVisible(true);
+    setDatePickerType(datePickerType);
+  };
+
+  const hideDatePicker = () => {
+    setIsDatePickerVisible(false);
+    setDatePickerType(null);
+  };
+
+  const handleConfirm = (date: Date) => {
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    console.log(hours, minutes);
+
+    if (datePickerType) {
+      settingMutate({
+        ...data.result,
+        [datePickerType]: `${hours}:${minutes}:00`,
+      });
+    }
+
+    hideDatePicker();
+  };
 
   const handlePrevButton = () => {
     router.back();
@@ -51,13 +84,14 @@ function SettingPage({ data }: Props): JSX.Element {
       </S.TitleBox>
       <ScrollView showsVerticalScrollIndicator={false}>
         <S.SettingBox>
-          <S.ItemButton hitSlop={10}>
+          <S.ItemButton hitSlop={10} onPress={() => showDatePicker("sleepTime")}>
             <S.ItemTitleBox>
               <S.ItemTitleText>자는 시간 설정</S.ItemTitleText>
               <S.ItemDescriptionText>해당 시간에 대화를 초기화 해드려요</S.ItemDescriptionText>
             </S.ItemTitleBox>
-            <S.ItemValueText>{sleepTime}</S.ItemValueText>
+            <S.ItemValueText>{sleepTime.slice(0, -3)}</S.ItemValueText>
           </S.ItemButton>
+
           <S.ItemButton disabled={true}>
             <S.ItemTitleBox>
               <S.ItemTitleText>푸시 알림</S.ItemTitleText>
@@ -65,14 +99,16 @@ function SettingPage({ data }: Props): JSX.Element {
             </S.ItemTitleBox>
             <Switch value={notificationSummary} onChange={handleNotificationSummary} />
           </S.ItemButton>
-          <S.ItemButton hitSlop={10}>
+
+          <S.ItemButton hitSlop={10} onPress={() => showDatePicker("notificationTime")}>
             <S.ItemTitleBox>
               <S.ItemTitleText>알림 시간 설정</S.ItemTitleText>
               <S.ItemDescriptionText>원하는 시간에 대화할 수 있도록</S.ItemDescriptionText>
               <S.ItemDescriptionText>앱 푸시 알림을 보내드려요</S.ItemDescriptionText>
             </S.ItemTitleBox>
-            <S.ItemValueText>{notificationTime}</S.ItemValueText>
+            <S.ItemValueText>{notificationTime.slice(0, -3)}</S.ItemValueText>
           </S.ItemButton>
+
           <S.ItemButton hitSlop={10}>
             <S.ItemTitleBox>
               <S.ItemTitleText>의견 보내기</S.ItemTitleText>
@@ -80,6 +116,7 @@ function SettingPage({ data }: Props): JSX.Element {
               <S.ItemDescriptionText>전달해주세요</S.ItemDescriptionText>
             </S.ItemTitleBox>
           </S.ItemButton>
+
           <S.ItemButton hitSlop={10}>
             <S.ItemTitleBox>
               <S.ItemTitleText>후원하기</S.ItemTitleText>
@@ -87,6 +124,7 @@ function SettingPage({ data }: Props): JSX.Element {
               <S.ItemDescriptionText>큰 도움이 됩니다</S.ItemDescriptionText>
             </S.ItemTitleBox>
           </S.ItemButton>
+
           <S.ItemButton hitSlop={10} onPress={handleLogout}>
             <S.ItemTitleBox>
               <S.ItemTitleText>로그아웃</S.ItemTitleText>
@@ -94,6 +132,13 @@ function SettingPage({ data }: Props): JSX.Element {
           </S.ItemButton>
         </S.SettingBox>
       </ScrollView>
+
+      <DateTimePickerModal
+        isVisible={isDatePickerVisible}
+        mode="time"
+        onConfirm={handleConfirm}
+        onCancel={hideDatePicker}
+      />
     </S.SafeView>
   );
 }

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -2,8 +2,10 @@ import { ScrollView, Switch } from "react-native";
 import { useRouter } from "expo-router";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import Ionicons from "@expo/vector-icons/Ionicons";
-import { UserSettingResult } from "@/src/types/settingTypes";
+import Loading from "@/src/components/ui/Loading";
 import useUpdateSetting from "@/src/hooks/useUpdateSetting";
+import useLogout from "@/src/hooks/useLogout";
+import { UserSettingResult } from "@/src/types/settingTypes";
 import { theme } from "@/src/constants/theme";
 import * as S from "./styles";
 
@@ -14,18 +16,27 @@ interface Props {
 function SettingPage({ data }: Props): JSX.Element {
   const { sleepTime, notificationSummary, notificationTime } = data.result;
   const router = useRouter();
-  const { mutate } = useUpdateSetting(data);
+  const { mutate: settingMutate } = useUpdateSetting(data);
+  const { isPending, mutate: logoutMutate } = useLogout();
 
   const handlePrevButton = () => {
     router.back();
   };
 
+  const handleLogout = () => {
+    logoutMutate();
+  };
+
   const handleNotificationSummary = () => {
-    mutate({
+    settingMutate({
       ...data.result,
       notificationSummary: !notificationSummary,
     });
   };
+
+  if (isPending) {
+    return <Loading />;
+  }
 
   return (
     <S.SafeView>
@@ -76,7 +87,7 @@ function SettingPage({ data }: Props): JSX.Element {
               <S.ItemDescriptionText>큰 도움이 됩니다</S.ItemDescriptionText>
             </S.ItemTitleBox>
           </S.ItemButton>
-          <S.ItemButton hitSlop={10}>
+          <S.ItemButton hitSlop={10} onPress={handleLogout}>
             <S.ItemTitleBox>
               <S.ItemTitleText>로그아웃</S.ItemTitleText>
             </S.ItemTitleBox>

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -1,6 +1,11 @@
+import { UserSettingResult } from "@/src/types/settingTypes";
 import * as S from "./styles";
 
-function SettingPage(): JSX.Element {
+interface Props {
+  data: UserSettingResult;
+}
+
+function SettingPage({ data }: Props): JSX.Element {
   return (
     <S.SafeView>
       <S.TempText>설정 페이지</S.TempText>

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -1,4 +1,9 @@
+import { ScrollView, Switch } from "react-native";
+import { useRouter } from "expo-router";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import Ionicons from "@expo/vector-icons/Ionicons";
 import { UserSettingResult } from "@/src/types/settingTypes";
+import { theme } from "@/src/constants/theme";
 import * as S from "./styles";
 
 interface Props {
@@ -6,9 +11,68 @@ interface Props {
 }
 
 function SettingPage({ data }: Props): JSX.Element {
+  const router = useRouter();
+
+  const handlePrevButton = () => {
+    router.back();
+  };
+
   return (
     <S.SafeView>
-      <S.TempText>설정 페이지</S.TempText>
+      <S.HeaderBox>
+        <S.PrevButton hitSlop={15} onPress={handlePrevButton}>
+          <MaterialIcons name="arrow-back-ios" size={24} color="black" />
+        </S.PrevButton>
+      </S.HeaderBox>
+      <S.TitleBox>
+        <Ionicons name="settings-sharp" size={42} color={theme.colors.deepGreen} />
+        <S.TitleText>설정</S.TitleText>
+      </S.TitleBox>
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <S.SettingBox>
+          <S.ItemButton hitSlop={10}>
+            <S.ItemTitleBox>
+              <S.ItemTitleText>자는 시간 설정</S.ItemTitleText>
+              <S.ItemDescriptionText>해당 시간에 대화를 초기화 해드려요</S.ItemDescriptionText>
+            </S.ItemTitleBox>
+            <S.ItemValueText>{data.result.sleepTime}</S.ItemValueText>
+          </S.ItemButton>
+          <S.ItemButton disabled={true}>
+            <S.ItemTitleBox>
+              <S.ItemTitleText>푸시 알림</S.ItemTitleText>
+              <S.ItemDescriptionText>푸시 알림을 허용/차단할 수 있어요</S.ItemDescriptionText>
+            </S.ItemTitleBox>
+            <Switch value={data.result.notificationSummary} />
+          </S.ItemButton>
+          <S.ItemButton hitSlop={10}>
+            <S.ItemTitleBox>
+              <S.ItemTitleText>알림 시간 설정</S.ItemTitleText>
+              <S.ItemDescriptionText>원하는 시간에 대화할 수 있도록</S.ItemDescriptionText>
+              <S.ItemDescriptionText>앱 푸시 알림을 보내드려요</S.ItemDescriptionText>
+            </S.ItemTitleBox>
+            <S.ItemValueText>{data.result.notificationTime}</S.ItemValueText>
+          </S.ItemButton>
+          <S.ItemButton hitSlop={10}>
+            <S.ItemTitleBox>
+              <S.ItemTitleText>의견 보내기</S.ItemTitleText>
+              <S.ItemDescriptionText>운영진에게 앱에 대한 의견을</S.ItemDescriptionText>
+              <S.ItemDescriptionText>전달해주세요</S.ItemDescriptionText>
+            </S.ItemTitleBox>
+          </S.ItemButton>
+          <S.ItemButton hitSlop={10}>
+            <S.ItemTitleBox>
+              <S.ItemTitleText>후원하기</S.ItemTitleText>
+              <S.ItemDescriptionText>후원은 Melissa 서비스 운영에</S.ItemDescriptionText>
+              <S.ItemDescriptionText>큰 도움이 됩니다</S.ItemDescriptionText>
+            </S.ItemTitleBox>
+          </S.ItemButton>
+          <S.ItemButton hitSlop={10}>
+            <S.ItemTitleBox>
+              <S.ItemTitleText>로그아웃</S.ItemTitleText>
+            </S.ItemTitleBox>
+          </S.ItemButton>
+        </S.SettingBox>
+      </ScrollView>
     </S.SafeView>
   );
 }

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ScrollView, Switch } from "react-native";
 import { useRouter } from "expo-router";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
@@ -18,6 +18,7 @@ interface Props {
 function SettingPage({ data }: Props): JSX.Element {
   const { sleepTime, notificationSummary, notificationTime } = data.result;
 
+  const [optimisticToggle, setOptimisticToggle] = useState<boolean>(notificationSummary);
   const [isDatePickerVisible, setIsDatePickerVisible] = useState<boolean>(false);
   const [datePickerType, setDatePickerType] = useState<"sleepTime" | "notificationTime" | null>(
     null
@@ -61,11 +62,16 @@ function SettingPage({ data }: Props): JSX.Element {
   };
 
   const handleNotificationSummary = () => {
+    setOptimisticToggle(!notificationSummary);
     settingMutate({
       ...data.result,
       notificationSummary: !notificationSummary,
     });
   };
+
+  useEffect(() => {
+    setOptimisticToggle(notificationSummary);
+  }, [notificationSummary]);
 
   if (isPending) {
     return <Loading />;
@@ -97,7 +103,7 @@ function SettingPage({ data }: Props): JSX.Element {
               <S.ItemTitleText>푸시 알림</S.ItemTitleText>
               <S.ItemDescriptionText>푸시 알림을 허용/차단할 수 있어요</S.ItemDescriptionText>
             </S.ItemTitleBox>
-            <Switch value={notificationSummary} onChange={handleNotificationSummary} />
+            <Switch value={optimisticToggle} onChange={handleNotificationSummary} />
           </S.ItemButton>
 
           <S.ItemButton hitSlop={10} onPress={() => showDatePicker("notificationTime")}>

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -1,0 +1,11 @@
+import * as S from "./styles";
+
+function SettingPage(): JSX.Element {
+  return (
+    <S.SafeView>
+      <S.TempText>설정 페이지</S.TempText>
+    </S.SafeView>
+  );
+}
+
+export default SettingPage;

--- a/src/pages/Setting/styles.ts
+++ b/src/pages/Setting/styles.ts
@@ -1,0 +1,10 @@
+import { SafeAreaView } from "react-native-safe-area-context";
+import styled from "styled-components/native";
+
+export const SafeView = styled(SafeAreaView)`
+  flex: 1;
+`;
+
+export const TempText = styled.Text`
+  font-size: 40px;
+`;

--- a/src/pages/Setting/styles.ts
+++ b/src/pages/Setting/styles.ts
@@ -1,10 +1,75 @@
+import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
 
 export const SafeView = styled(SafeAreaView)`
   flex: 1;
+  padding: ${responsiveToPx("26px")};
+  background-color: ${({ theme }) => theme.colors.whiteBlue};
 `;
 
-export const TempText = styled.Text`
-  font-size: 40px;
+export const HeaderBox = styled.View`
+  height: ${responsiveToPxByHeight("68px")};
+  justify-content: center;
+`;
+
+export const PrevButton = styled.TouchableOpacity`
+  width: ${responsiveToPx("24px")};
+  height: ${responsiveToPx("24px")};
+`;
+
+// --------------------------------------------------------------------
+
+export const TitleBox = styled.View`
+  width: 100%;
+  flex-direction: row;
+  height: ${responsiveToPxByHeight("164px")};
+  align-items: center;
+  gap: ${({ theme }) => theme.gap.base};
+`;
+
+export const TitleText = styled.Text`
+  font-family: ${({ theme }) => theme.fontFamily.nsBold};
+  font-size: ${({ theme }) => theme.fontSize.xl};
+`;
+
+// --------------------------------------------------------------------
+
+export const SettingBox = styled.View`
+  width: 100%;
+  padding: ${responsiveToPx("22px")} ${responsiveToPx("33px")};
+  border-radius: ${({ theme }) => theme.borderRadius.lg};
+  background-color: ${({ theme }) => theme.colors.white};
+  justify-content: center;
+  align-items: center;
+  gap: ${({ theme }) => theme.gap.xxl};
+`;
+
+export const ItemButton = styled.TouchableOpacity`
+  width: 100%;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const ItemTitleBox = styled.View`
+  gap: ${({ theme }) => theme.gap.sm};
+`;
+
+export const ItemTitleText = styled.Text`
+  font-family: ${({ theme }) => theme.fontFamily.nsRegular};
+  font-size: ${({ theme }) => theme.fontSize.md};
+  color: ${({ theme }) => theme.colors.settingText};
+`;
+
+export const ItemDescriptionText = styled.Text`
+  font-family: ${({ theme }) => theme.fontFamily.nsRegular};
+  font-size: ${({ theme }) => theme.fontSize.xs};
+  color: ${({ theme }) => theme.colors.settingSubText};
+`;
+
+export const ItemValueText = styled.Text`
+  font-family: ${({ theme }) => theme.fontFamily.podkovaRegular};
+  font-size: ${({ theme }) => theme.fontSize.md};
+  color: ${({ theme }) => theme.colors.settingValueText};
 `;

--- a/src/types/settingTypes.ts
+++ b/src/types/settingTypes.ts
@@ -3,3 +3,11 @@ import { SuccessResponse } from "./commonTypes";
 export type CheckNewUserType = SuccessResponse & { result: boolean };
 
 export type RegisterSettingType = SuccessResponse & { result: null };
+
+export type UserSettingResult = SuccessResponse & {
+  result: {
+    sleepTime: string;
+    notificationTime: string;
+    notificationSummary: boolean;
+  };
+};

--- a/src/utils/responsiveToPx.ts
+++ b/src/utils/responsiveToPx.ts
@@ -4,7 +4,8 @@ import { Dimensions } from "react-native";
  * Figma 화면 사이즈 (가로 기준)
  */
 const baseDesignScreenSize = 430;
-const { width } = Dimensions.get("window");
+const baseDesignScreenSizeByHeight = 932;
+const { width, height } = Dimensions.get("window");
 
 /**
  * @description 모바일 화면 크기에 맞게 조절된 px 반환
@@ -12,6 +13,11 @@ const { width } = Dimensions.get("window");
 function responsiveToPx(pixel: string): string {
   const screenRatio = width / baseDesignScreenSize;
   return `${(parseInt(pixel) * screenRatio).toFixed(2)}px`;
+}
+
+export function responsiveToPxByHeight(pixel: string): string {
+  const screenRatioByHeight = height / baseDesignScreenSizeByHeight;
+  return `${(parseInt(pixel) * screenRatioByHeight).toFixed(2)}px`;
 }
 
 export default responsiveToPx;


### PR DESCRIPTION
# 개요

- 사용자가 자는 시간/푸시 알림 유무/알림 시간을 설정하고, 문의, 후원, 로그아웃을 수행할 수 있는 설정 페이지 구현
- `mutation`이 처리되는 동안 로딩화면을 보여주는 대신, 낙관적 업데이트 (`optimistic update`)를 적용
    - 우선 `mutation`을 실행하기 전, `onMutate`에서 설정 쿼리를 사용자가 입력한 값으로 미리 업데이트
    - 요청에 성공하면, 쿼리를 그대로 둠
    - 요청에 실패하면, 쿼리를 `invalidate` 시켜서 서버의 값을 다시 가져와 반영
- 설정값들은 수정을 하기 전까지 거의 변하지 않을 것이므로 `staleTime`을 5분으로 지정
- 의견 보내기, 후원하기는 다른 기능 구현이 더 급하므로 우선 제외
- 추후 `mutation` 성공/실패 시 적절한 `toast message`로 사용자에게 안내하도록 기능을 추가할 예정

---

## 구현

- [X] 누락된 네비게이터 설정을 `Stack`으로 설정
- [X] 메인 페이지에서 설정 버튼 누르면 스택 네비게이터로 설정 페이지 푸시
- [X] 설정 페이지 `queryFn`과 `useQuery` 구현 (`staleTime`: 5분)
- [X] 설정 페이지 레이아웃 구현
- [X] 설정을 변경하면 수행할 `mutationFn`과 `useMutation` 구현 (`useUpdateSetting`)
- [X] 낙관적 업데이트 적용 (`onMutate`에서 미리 예상 결과로 쿼리 업데이트)
- [X] 요청 실패 시 낙관적 업데이트 롤백 (`invalidateQueries`)
- [X] 로그아웃을 수행할 `mutationFn`과 `useMutation` 구현 (`useLogout`)
- [X] 로그아웃, 푸시알림 미허용/허용 토글 기능 구현
- [X] 시간 설정 라이브러리 연결 [react-native-modal-datetime-picker](https://github.com/mmazzarolo/react-native-modal-datetime-picker)
- [X] 자는 시간, 알림 시간 변경 기능 구현

---

## 구현 결과

https://github.com/user-attachments/assets/7550e644-2e50-4855-a8c8-500c58526155

---