### PR TITLE
console.error, Alert를 Toast message로 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "react-native-sse": "^1.2.1",
+    "react-native-toast-message": "^2.2.1",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
     "styled-components": "6.1.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       react-native-sse:
         specifier: ^1.2.1
         version: 1.2.1
+      react-native-toast-message:
+        specifier: ^2.2.1
+        version: 2.2.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
       react-native-web:
         specifier: ~0.19.13
         version: 0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4391,6 +4394,12 @@ packages:
 
   react-native-swipe-gestures@1.0.5:
     resolution: {integrity: sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==}
+
+  react-native-toast-message@2.2.1:
+    resolution: {integrity: sha512-iXFMnlxPcgKKs4bZOIl06W16m6KXMh/bAYpWLyVXlISSCdcL2+FX5WPpRP3TGQeM/u9q+j5ex48DDY+72en+Sw==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   react-native-web@0.19.13:
     resolution: {integrity: sha512-etv3bN8rJglrRCp/uL4p7l8QvUNUC++QwDbdZ8CB7BvZiMvsxfFIRM1j04vxNldG3uo2puRd6OSWR3ibtmc29A==}
@@ -10954,6 +10963,11 @@ snapshots:
   react-native-sse@1.2.1: {}
 
   react-native-swipe-gestures@1.0.5: {}
+
+  react-native-toast-message@2.2.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-native: 0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)
 
   react-native-web@0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -4,6 +4,7 @@ import { Slot } from "expo-router";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { useReactQueryDevTools } from "@dev-plugins/react-query";
 import { useEffect, useState } from "react";
+import Toast from "react-native-toast-message";
 import { ThemeProvider } from "styled-components/native";
 import { theme } from "@/src/constants/theme";
 import queryClient from "@/src/libs/queryClient";
@@ -35,6 +36,7 @@ function RootLayout() {
       <QueryClientProvider client={queryClient}>
         <StatusBar />
         <Slot />
+        <Toast />
       </QueryClientProvider>
     </ThemeProvider>
   );

--- a/src/constants/toastMessage.ts
+++ b/src/constants/toastMessage.ts
@@ -1,0 +1,27 @@
+const toastMessage = {
+  fontLoading: {
+    failed: "앱 초기 로딩에 실패했어요. 잠시 후 다시 시도해주세요.",
+  },
+  login: {
+    success: "로그인에 성공했습니다.",
+    failed: "로그인에 실패했습니다.",
+  },
+  logout: {
+    success: "로그아웃에 성공했습니다.",
+    failed: "로그아웃에 실패했습니다.",
+  },
+  tokenExpired: "세션이 만료되었습니다. 다시 로그인 해주세요.",
+  registerSetting: {
+    failed: "앱 초기 로딩 중 에러가 발생했어요.",
+  },
+  updateSetting: {
+    success: "설정 업데이트 완료.",
+    failed: "설정 업데이트 도중 문제 발생.",
+  },
+  removeAssistant: {
+    success: "서포터가 삭제되었습니다.",
+    failed: "서포터 삭제에 실패했습니다. 다시 시도해주세요.",
+  },
+};
+
+export default toastMessage;

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -6,6 +6,7 @@ import { setSecureValue } from "../libs/secureStorage";
 import { setStorageValue } from "../libs/mmkv";
 import { ErrorResponse } from "../types/commonTypes";
 import { LoginType } from "../types/loginTypes";
+import toastMessage from "@/src/constants/toastMessage";
 import showToast from "@/src/libs/showToast";
 
 const useLogin = () => {
@@ -18,14 +19,14 @@ const useLogin = () => {
     await setSecureValue("refreshToken", data.result.refreshToken);
     queryClient.invalidateQueries({ queryKey: ["check-new-user"] });
     router.replace("/(app)");
-    showToast("로그인에 성공했습니다.", "success");
+    showToast(toastMessage.login.success, "success");
   };
 
   const handleError = (error: unknown) => {
     console.error("로그인 실패!", error);
     if (isAxiosError<ErrorResponse>(error)) {
       console.error("OAuth 프로바이더 정상 작동, 백엔드와 문제 발생", error.response?.data);
-      showToast("로그인에 실패했습니다.", "error");
+      showToast(toastMessage.login.failed, "error");
     }
   };
 

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,4 +1,3 @@
-import { Alert } from "react-native";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { isAxiosError } from "axios";
@@ -7,6 +6,7 @@ import { setSecureValue } from "../libs/secureStorage";
 import { setStorageValue } from "../libs/mmkv";
 import { ErrorResponse } from "../types/commonTypes";
 import { LoginType } from "../types/loginTypes";
+import showToast from "@/src/libs/showToast";
 
 const useLogin = () => {
   const queryClient = useQueryClient();
@@ -18,13 +18,14 @@ const useLogin = () => {
     await setSecureValue("refreshToken", data.result.refreshToken);
     queryClient.invalidateQueries({ queryKey: ["check-new-user"] });
     router.replace("/(app)");
+    showToast("로그인에 성공했습니다.", "success");
   };
 
   const handleError = (error: unknown) => {
     console.error("로그인 실패!", error);
     if (isAxiosError<ErrorResponse>(error)) {
       console.error("OAuth 프로바이더 정상 작동, 백엔드와 문제 발생", error.response?.data);
-      Alert.alert("로그인에 실패했습니다.");
+      showToast("로그인에 실패했습니다.", "error");
     }
   };
 

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,15 +1,16 @@
+import { router } from "expo-router";
 import { useMutation } from "@tanstack/react-query";
 import { logoutFn } from "@/src/apis/loginApi";
 import { removeSecureValue } from "@/src/libs/secureStorage";
 import { removeStorageValue } from "@/src/libs/mmkv";
-import { router } from "expo-router";
+import toastMessage from "@/src/constants/toastMessage";
 import showToast from "@/src/libs/showToast";
 
 const useLogout = () => {
   return useMutation({
     mutationFn: logoutFn,
     onSuccess: async (data) => {
-      showToast("로그아웃에 성공했습니다.", "success");
+      showToast(toastMessage.logout.success, "success");
       console.log(data);
       await removeSecureValue("refreshToken");
       removeStorageValue("accessToken");
@@ -17,7 +18,7 @@ const useLogout = () => {
     },
     onError: (error) => {
       console.error(error.response?.data);
-      showToast("로그아웃에 실패했습니다.", "error");
+      showToast(toastMessage.logout.failed, "error");
     },
   });
 };

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -3,12 +3,13 @@ import { logoutFn } from "@/src/apis/loginApi";
 import { removeSecureValue } from "@/src/libs/secureStorage";
 import { removeStorageValue } from "@/src/libs/mmkv";
 import { router } from "expo-router";
+import showToast from "@/src/libs/showToast";
 
 const useLogout = () => {
   return useMutation({
     mutationFn: logoutFn,
     onSuccess: async (data) => {
-      // Todo: 로그아웃 성공 Toast message 추가
+      showToast("로그아웃에 성공했습니다.", "success");
       console.log(data);
       await removeSecureValue("refreshToken");
       removeStorageValue("accessToken");
@@ -16,7 +17,7 @@ const useLogout = () => {
     },
     onError: (error) => {
       console.error(error.response?.data);
-      // Todo: 로그아웃 실패 Toast message 추가
+      showToast("로그아웃에 실패했습니다.", "error");
     },
   });
 };

--- a/src/hooks/useRegisterSetting.ts
+++ b/src/hooks/useRegisterSetting.ts
@@ -1,4 +1,5 @@
 import { registerSettingFn } from "@/src/apis/settingApi";
+import showToast from "@/src/libs/showToast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 const useRegisterSetting = () => {
@@ -12,6 +13,7 @@ const useRegisterSetting = () => {
     },
     onError: (error) => {
       console.error(error.response?.data);
+      showToast("앱 초기 로딩 중 에러가 발생했어요.", "error");
     },
   });
 };

--- a/src/hooks/useRegisterSetting.ts
+++ b/src/hooks/useRegisterSetting.ts
@@ -1,6 +1,7 @@
-import { registerSettingFn } from "@/src/apis/settingApi";
-import showToast from "@/src/libs/showToast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { registerSettingFn } from "@/src/apis/settingApi";
+import toastMessage from "@/src/constants/toastMessage";
+import showToast from "@/src/libs/showToast";
 
 const useRegisterSetting = () => {
   const queryClient = useQueryClient();
@@ -13,7 +14,7 @@ const useRegisterSetting = () => {
     },
     onError: (error) => {
       console.error(error.response?.data);
-      showToast("앱 초기 로딩 중 에러가 발생했어요.", "error");
+      showToast(toastMessage.registerSetting.failed, "error");
     },
   });
 };

--- a/src/hooks/useRemoveAssistant.ts
+++ b/src/hooks/useRemoveAssistant.ts
@@ -1,5 +1,6 @@
-import { removeAssistantFn } from "@/src/apis/aiProfileApi";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { removeAssistantFn } from "@/src/apis/aiProfileApi";
+import toastMessage from "@/src/constants/toastMessage";
 import showToast from "@/src/libs/showToast";
 
 const useRemoveAssistant = () => {
@@ -10,11 +11,11 @@ const useRemoveAssistant = () => {
     onSuccess: (data) => {
       console.log(data);
       queryClient.invalidateQueries({ queryKey: ["assistant-list"] });
-      showToast("서포터가 삭제되었습니다.", "success");
+      showToast(toastMessage.removeAssistant.success, "success");
     },
     onError: (error) => {
       console.error(error.response?.data);
-      showToast("서포터 삭제에 실패했습니다. 다시 시도해주세요.", "error");
+      showToast(toastMessage.removeAssistant.failed, "error");
     },
   });
 };

--- a/src/hooks/useRemoveAssistant.ts
+++ b/src/hooks/useRemoveAssistant.ts
@@ -1,6 +1,6 @@
 import { removeAssistantFn } from "@/src/apis/aiProfileApi";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Alert } from "react-native";
+import showToast from "@/src/libs/showToast";
 
 const useRemoveAssistant = () => {
   const queryClient = useQueryClient();
@@ -10,11 +10,11 @@ const useRemoveAssistant = () => {
     onSuccess: (data) => {
       console.log(data);
       queryClient.invalidateQueries({ queryKey: ["assistant-list"] });
-      Alert.alert("삭제되었습니다.");
+      showToast("서포터가 삭제되었습니다.", "success");
     },
     onError: (error) => {
       console.error(error.response?.data);
-      Alert.alert("삭제에 실패했습니다. 다시 시도해주세요.");
+      showToast("서포터 삭제에 실패했습니다. 다시 시도해주세요.", "error");
     },
   });
 };

--- a/src/hooks/useUpdateSetting.ts
+++ b/src/hooks/useUpdateSetting.ts
@@ -1,7 +1,8 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { putUserSettingFn } from "@/src/apis/settingApi";
+import toastMessage from "@/src/constants/toastMessage";
 import showToast from "@/src/libs/showToast";
 import { UserSettingResult } from "@/src/types/settingTypes";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 const useUpdateSetting = (data: UserSettingResult) => {
   const queryClient = useQueryClient();
@@ -15,13 +16,13 @@ const useUpdateSetting = (data: UserSettingResult) => {
     },
     onSuccess: (data) => {
       console.log("성공", data);
-      showToast("설정 업데이트 완료.", "success");
+      showToast(toastMessage.updateSetting.success, "success");
     },
     onError: (error) => {
       console.error(error.response?.data);
       // 요청에 실패했으므로 서버에서 값 가져와 롤백
       queryClient.invalidateQueries({ queryKey: ["user-setting"] });
-      showToast("설정 업데이트 도중 문제 발생.", "error");
+      showToast(toastMessage.updateSetting.failed, "error");
     },
   });
 };

--- a/src/hooks/useUpdateSetting.ts
+++ b/src/hooks/useUpdateSetting.ts
@@ -1,4 +1,5 @@
 import { putUserSettingFn } from "@/src/apis/settingApi";
+import showToast from "@/src/libs/showToast";
 import { UserSettingResult } from "@/src/types/settingTypes";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
@@ -14,12 +15,13 @@ const useUpdateSetting = (data: UserSettingResult) => {
     },
     onSuccess: (data) => {
       console.log("성공", data);
+      showToast("설정 업데이트 완료.", "success");
     },
     onError: (error) => {
       console.error(error.response?.data);
       // 요청에 실패했으므로 서버에서 값 가져와 롤백
       queryClient.invalidateQueries({ queryKey: ["user-setting"] });
-      // Todo: 토스트 메시지로 에러 원인 알려주기
+      showToast("설정 업데이트 도중 문제 발생.", "error");
     },
   });
 };

--- a/src/libs/axiosInstance.ts
+++ b/src/libs/axiosInstance.ts
@@ -1,11 +1,11 @@
 import axios, { AxiosResponse } from "axios";
-import { Alert } from "react-native";
 import { router } from "expo-router";
 import { getStorageValue, setStorageValue, removeStorageValue } from "./mmkv";
 import { getSecureValue, removeSecureValue, setSecureValue } from "./secureStorage";
 import endpoint from "../constants/endpoint";
 import { LoginType } from "../types/loginTypes";
 import { AxiosErrorToInterceptors, ErrorResponse } from "../types/commonTypes";
+import showToast from "@/src/libs/showToast";
 
 /**
  * 토큰 refresh 도중 새로 발생한 401 error 콜백 함수 Type
@@ -107,7 +107,7 @@ axiosInstance.interceptors.response.use(
         console.error("토큰 재발급 로직 도중 에러", e);
         removeSecureValue("refreshToken");
         removeStorageValue("accessToken");
-        Alert.alert("세션이 만료되었습니다. 다시 로그인 해주세요.");
+        showToast("세션이 만료되었습니다. 다시 로그인 해주세요.", "error");
         router.replace("/login");
         return Promise.reject(error);
       } finally {

--- a/src/libs/axiosInstance.ts
+++ b/src/libs/axiosInstance.ts
@@ -5,6 +5,7 @@ import { getSecureValue, removeSecureValue, setSecureValue } from "./secureStora
 import endpoint from "../constants/endpoint";
 import { LoginType } from "../types/loginTypes";
 import { AxiosErrorToInterceptors, ErrorResponse } from "../types/commonTypes";
+import toastMessage from "@/src/constants/toastMessage";
 import showToast from "@/src/libs/showToast";
 
 /**
@@ -107,7 +108,7 @@ axiosInstance.interceptors.response.use(
         console.error("토큰 재발급 로직 도중 에러", e);
         removeSecureValue("refreshToken");
         removeStorageValue("accessToken");
-        showToast("세션이 만료되었습니다. 다시 로그인 해주세요.", "error");
+        showToast(toastMessage.tokenExpired, "error");
         router.replace("/login");
         return Promise.reject(error);
       } finally {

--- a/src/libs/queryClient.ts
+++ b/src/libs/queryClient.ts
@@ -1,5 +1,5 @@
 import { QueryCache, QueryClient } from "@tanstack/react-query";
-import { Alert } from "react-native";
+import showToast from "@/src/libs/showToast";
 
 export default new QueryClient({
   defaultOptions: {
@@ -12,7 +12,7 @@ export default new QueryClient({
     onError: (error) => {
       console.log(error.response?.data);
       if (error.response?.data.code !== "401") {
-        Alert.alert(error.response?.data.message || "알 수 없는 에러가 발생했습니다.");
+        showToast(error.response?.data.message, "error");
       }
     },
   }),

--- a/src/libs/showToast.ts
+++ b/src/libs/showToast.ts
@@ -1,0 +1,20 @@
+import { theme } from "@/src/constants/theme";
+import Toast from "react-native-toast-message";
+
+type MessageType = "error" | "success";
+
+const showToast = (message: string | undefined, type: MessageType) => {
+  if (message) {
+    Toast.show({
+      type: type,
+      position: "bottom",
+      text1: message,
+      text1Style: {
+        fontSize: parseInt(theme.fontSize.base),
+        fontFamily: theme.fontFamily.nsRegular,
+      },
+    });
+  }
+};
+
+export default showToast;

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "expo-router";
 import { CalendarList, DateData, LocaleConfig } from "react-native-calendars";
 import useCurrentDate from "@/src/hooks/useCurrentDate";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
@@ -5,7 +6,6 @@ import DayComponent from "./DayComponent";
 import ChatButton from "./ChatButton";
 import { theme } from "@/src/constants/theme";
 import * as S from "./styles";
-import { useRouter } from "expo-router";
 
 LocaleConfig.locales["ko"] = {
   monthNames: [

--- a/src/utils/initializeApp.ts
+++ b/src/utils/initializeApp.ts
@@ -1,5 +1,6 @@
 import * as Font from "expo-font";
 import { Dispatch, SetStateAction } from "react";
+import toastMessage from "@/src/constants/toastMessage";
 import showToast from "@/src/libs/showToast";
 
 /**
@@ -29,7 +30,7 @@ const initializeApp = async (setIsReady: Dispatch<SetStateAction<boolean>>) => {
     await Promise.all([loadFonts()]);
   } catch (e) {
     console.error(e);
-    showToast("앱 초기 로딩에 실패했어요. 잠시 후 다시 시도해주세요.", "error");
+    showToast(toastMessage.fontLoading.failed, "error");
   } finally {
     setIsReady(true);
   }

--- a/src/utils/initializeApp.ts
+++ b/src/utils/initializeApp.ts
@@ -1,5 +1,6 @@
 import * as Font from "expo-font";
 import { Dispatch, SetStateAction } from "react";
+import showToast from "@/src/libs/showToast";
 
 /**
  * @description 필요한 모든 폰트를 로딩하는 함수
@@ -28,7 +29,7 @@ const initializeApp = async (setIsReady: Dispatch<SetStateAction<boolean>>) => {
     await Promise.all([loadFonts()]);
   } catch (e) {
     console.error(e);
-    // Todo: 추가 에러 처리(폰트 로딩 실패 등)
+    showToast("앱 초기 로딩에 실패했어요. 잠시 후 다시 시도해주세요.", "error");
   } finally {
     setIsReady(true);
   }


### PR DESCRIPTION
# 개요

기존에는 API 통신 성공/실패를 유저에게 인식시키기 위한 알림이 부실했다. 내장 Alert의 경우 확인 버튼을 누르기 전까지 사용자의 행동을 blocking 하므로 UX상 좋지 않다.

예를 들어 로그인 성공, 로그인 실패, 어시스턴트 삭제 실패, 설정 변경 실패 등은 간단하게 사용자에게 인식시키기만 해도 큰 도움이 될 것이다.

이런 정보들을 Toast message로 전달하도록 구현했다.

여러 message들이 사방에 흩어져 있다면 수정이 불편하므로, constants 폴더 내에 `toastMessage.ts` 파일을 두고 중앙화시켜 관리하도록 했다.

사용 라이브러리: [react-native-toast-message](https://github.com/calintamas/react-native-toast-message)