### PR TITLE
애플 로그인 구현, 다크모드 버그 수정, 로그아웃 시 캐시 초기화

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@tanstack/react-query": "^5.64.2",
     "axios": "^1.7.9",
     "expo": "~52.0.26",
+    "expo-apple-authentication": "~7.1.3",
     "expo-blur": "~14.0.2",
     "expo-build-properties": "~0.13.2",
     "expo-constants": "~17.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       expo:
         specifier: ~52.0.26
         version: 52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      expo-apple-authentication:
+        specifier: ~7.1.3
+        version: 7.1.3(expo@52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))
       expo-blur:
         specifier: ~14.0.2
         version: 14.0.2(expo@52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
@@ -2583,6 +2586,12 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  expo-apple-authentication@7.1.3:
+    resolution: {integrity: sha512-TRaF513oDGjGx3hRiAwkMiSnKLN8BIR9Se5Gi3ttz2UUgP9y+tNHV6Ji6/oztJo9ON7zerHg2mn5Y+3B8c2vTQ==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
 
   expo-asset@11.0.2:
     resolution: {integrity: sha512-We3Td5WsNsNQyXoheLnuwic6JCOt/pqXqIIyWaZ3z/PeHrA+SwoQdI18MjDhkudLK08tbIVyDSUW8IJHXa04eg==}
@@ -8726,6 +8735,11 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  expo-apple-authentication@7.1.3(expo@52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)):
+    dependencies:
+      expo: 52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      react-native: 0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)
 
   expo-asset@11.0.2(expo@52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/src/apis/loginApi.ts
+++ b/src/apis/loginApi.ts
@@ -1,5 +1,6 @@
 import { login } from "@react-native-seoul/kakao-login";
 import { GoogleSignin } from "@react-native-google-signin/google-signin";
+import * as AppleAuthentication from "expo-apple-authentication";
 import axiosInstance from "../libs/axiosInstance";
 import endpoint from "../constants/endpoint";
 import { SuccessResponse } from "@/src/types/commonTypes";
@@ -23,6 +24,19 @@ export const googleLoginFn = async () => {
 export const kakaoLoginFn = async () => {
   const { accessToken } = await login();
   const { data } = await axiosInstance.post<LoginType>(endpoint.auth.kakao, { accessToken });
+  return data;
+};
+
+export const appleLoginFn = async () => {
+  const { identityToken } = await AppleAuthentication.signInAsync({
+    requestedScopes: [
+      AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+      AppleAuthentication.AppleAuthenticationScope.EMAIL,
+    ],
+  });
+  const { data } = await axiosInstance.post<LoginType>(endpoint.auth.apple, {
+    idToken: identityToken,
+  });
   return data;
 };
 

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -34,7 +34,7 @@ function RootLayout() {
   return (
     <ThemeProvider theme={theme}>
       <QueryClientProvider client={queryClient}>
-        <StatusBar />
+        <StatusBar style="dark" />
         <Slot />
         <Toast />
       </QueryClientProvider>

--- a/src/components/ui/Loading/styles.ts
+++ b/src/components/ui/Loading/styles.ts
@@ -4,4 +4,5 @@ export const CenterView = styled.View`
   flex: 1;
   justify-content: center;
   align-items: center;
+  background-color: ${({ theme }) => theme.colors.white};
 `;

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { isAxiosError } from "axios";
-import { googleLoginFn, kakaoLoginFn } from "../apis/loginApi";
+import { appleLoginFn, googleLoginFn, kakaoLoginFn } from "../apis/loginApi";
 import { setSecureValue } from "../libs/secureStorage";
 import { setStorageValue } from "../libs/mmkv";
 import { ErrorResponse } from "../types/commonTypes";
@@ -42,9 +42,15 @@ const useLogin = () => {
     onError: handleError,
   });
 
-  const isPending = kakaoIsPending || googleIsPending;
+  const { isPending: appleIsPending, mutate: appleMutate } = useMutation({
+    mutationFn: appleLoginFn,
+    onSuccess: handleSuccess,
+    onError: handleError,
+  });
 
-  return { isPending, kakaoMutate, googleMutate };
+  const isPending = kakaoIsPending || googleIsPending || appleIsPending;
+
+  return { isPending, kakaoMutate, googleMutate, appleMutate };
 };
 
 export default useLogin;

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,5 +1,5 @@
 import { router } from "expo-router";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { logoutFn } from "@/src/apis/loginApi";
 import { removeSecureValue } from "@/src/libs/secureStorage";
 import { removeStorageValue } from "@/src/libs/mmkv";
@@ -7,6 +7,8 @@ import toastMessage from "@/src/constants/toastMessage";
 import showToast from "@/src/libs/showToast";
 
 const useLogout = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: logoutFn,
     onSuccess: async (data) => {
@@ -14,6 +16,7 @@ const useLogout = () => {
       console.log(data);
       await removeSecureValue("refreshToken");
       removeStorageValue("accessToken");
+      queryClient.clear(); // 로그아웃 후 다른 계정에 접속해도 캐시가 남아있는 문제 존재했음. 깜빡했다...
       router.replace("/login");
     },
     onError: (error) => {

--- a/src/libs/axiosInstance.ts
+++ b/src/libs/axiosInstance.ts
@@ -58,7 +58,14 @@ axiosInstance.interceptors.response.use(
     const { response, config } = error;
 
     // 401 에러는 refresh token으로 재발급 시도 후 성공하면 기존 요청 재시도
-    if (response && config && response.status === 401 && !config.sent) {
+    // 소셜 로그인 인증 실패 (OAuth 토큰 관련 문제)는 제외
+    if (
+      response &&
+      config &&
+      response.status === 401 &&
+      response.data.code !== "AUTH4001" &&
+      !config.sent
+    ) {
       // 해당 에러가 토큰 재발급 시도의 응답이 아니고, 이미 재발급 중이면 Queue에 대기시킴
       if (isRefreshing) {
         console.log("토큰 재발급중... 해당 요청을 Queue에 추가");

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,3 +1,4 @@
+import { Platform } from "react-native";
 import useLogin from "@/src/hooks/useLogin";
 import Loading from "@/src/components/ui/Loading";
 import LoginButton from "./LoginButton";
@@ -29,9 +30,11 @@ function LoginPage() {
           <LoginButton provider="google" onPress={googleMutate}>
             Google로 로그인
           </LoginButton>
-          <LoginButton provider="apple" onPress={handleClickApple}>
-            Apple로 로그인
-          </LoginButton>
+          {Platform.OS === "ios" && (
+            <LoginButton provider="apple" onPress={handleClickApple}>
+              Apple로 로그인
+            </LoginButton>
+          )}
         </S.ButtonBox>
       </S.ContentBox>
     </S.SafeView>

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -5,11 +5,7 @@ import LoginButton from "./LoginButton";
 import * as S from "./styles";
 
 function LoginPage() {
-  const { isPending, kakaoMutate, googleMutate } = useLogin();
-
-  const handleClickApple = () => {
-    console.log("애플 버튼 클릭");
-  };
+  const { isPending, kakaoMutate, googleMutate, appleMutate } = useLogin();
 
   if (isPending) {
     return <Loading />;
@@ -31,7 +27,7 @@ function LoginPage() {
             Google로 로그인
           </LoginButton>
           {Platform.OS === "ios" && (
-            <LoginButton provider="apple" onPress={handleClickApple}>
+            <LoginButton provider="apple" onPress={appleMutate}>
               Apple로 로그인
             </LoginButton>
           )}


### PR DESCRIPTION
# 개요

- 애플 로그인 구현을 위해 [expo-apple-authentication](https://docs.expo.dev/versions/latest/sdk/apple-authentication/) 활용
- Apple Developers 설정 (identifier 등록, key 등록) [참고 블로그](https://velog.io/@gs0428/React-Native-%EC%95%A0%ED%94%8C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84%ED%95%B4-%EB%B3%B4%EA%B8%B0)
- 애플 로그인 수행하는 `mutationFn`과 `useMutation` 구현 [참고 블로그](https://ddicreator.com/84)
- 기기가 다크모드인 경우, 모바일 상태바가 가려지는 문제 해결 (`expo-status-bar`의 `style`을 `dark`로 명시)
- 기기가 다크모드인 경우, 로딩 스피너 배경이 검정색인 문제 해결 (명시적으로 배경 흰색으로 지정)
- 소셜 로그인 실패(OAuth 토큰에 문제)시에도 `401` 상태코드가 반환되어, `axios interceptors`가 토큰 재발급을 시도하는 문제 확인 -> 재발급 로직에 조건문을 추가해 해결
- 로그아웃 시 Tanstack-query의 캐시를 삭제하지 않으니, 다른 계정으로 로그인해도 캘린더 데이터를 다시 받아오지 않는 문제 확인 -> 로그아웃 시 `queryClient.clear()` 수행해 해결

---

## 구현 결과

> 실 기기에서 돌려보는 만큼, 전체적으로 한번 싹 테스트 해보았다.
IOS bundle identifier를 변경해 3사 로그인이 전부 잘 되는지도 확인했다.

https://github.com/user-attachments/assets/f383b14b-3d12-456f-85a4-e9b4a0c33249

---