### PR TITLE
일기 팝업(바텀 시트) 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@dev-plugins/react-query": "^0.1.0",
     "@expo/vector-icons": "^14.0.2",
+    "@gorhom/bottom-sheet": "^5",
     "@react-native-community/datetimepicker": "8.2.0",
     "@react-native-google-signin/google-signin": "^13.1.0",
     "@react-native-seoul/kakao-login": "^5.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       '@expo/vector-icons':
         specifier: ^14.0.2
         version: 14.0.4
+      '@gorhom/bottom-sheet':
+        specifier: ^5
+        version: 5.0.6(@types/react@18.3.18)(react-native-gesture-handler@2.20.2(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native-reanimated@3.16.7(@babel/core@7.26.0)(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
       '@react-native-community/datetimepicker':
         specifier: 8.2.0
         version: 8.2.0(expo@52.0.26(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@expo/metro-runtime@4.0.1(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)))(react-native-webview@13.12.5(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
@@ -1019,6 +1022,27 @@ packages:
   '@expo/xcpretty@4.3.2':
     resolution: {integrity: sha512-ReZxZ8pdnoI3tP/dNnJdnmAk7uLT4FjsKDGW7YeDdvdOMz2XCQSmSCM9IWlrXuWtMF9zeSB6WJtEhCQ41gQOfw==}
     hasBin: true
+
+  '@gorhom/bottom-sheet@5.0.6':
+    resolution: {integrity: sha512-SI/AhPvgRfnCWN6/+wbE6TXwRE4X8F2fLyE4L/0bRwgE34Zenq585qLT139uEcfCIyovC2swC3ICqQpkmWEcFA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-native': '*'
+      react: '*'
+      react-native: '*'
+      react-native-gesture-handler: '>=2.16.1'
+      react-native-reanimated: '>=3.16.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-native':
+        optional: true
+
+  '@gorhom/portal@1.0.14':
+    resolution: {integrity: sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -6707,6 +6731,23 @@ snapshots:
       chalk: 4.1.2
       find-up: 5.0.0
       js-yaml: 4.1.0
+
+  '@gorhom/bottom-sheet@5.0.6(@types/react@18.3.18)(react-native-gesture-handler@2.20.2(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native-reanimated@3.16.7(@babel/core@7.26.0)(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1))(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@gorhom/portal': 1.0.14(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      invariant: 2.2.4
+      react: 18.3.1
+      react-native: 0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)
+      react-native-gesture-handler: 2.20.2(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+      react-native-reanimated: 3.16.7(@babel/core@7.26.0)(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+
+  '@gorhom/portal@1.0.14(react-native@0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      nanoid: 3.3.8
+      react: 18.3.1
+      react-native: 0.76.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(@types/react@18.3.18)(react@18.3.1)
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:

--- a/src/apis/calendarApi.ts
+++ b/src/apis/calendarApi.ts
@@ -1,6 +1,6 @@
 import endpoint from "@/src/constants/endpoint";
 import axiosInstance from "@/src/libs/axiosInstance";
-import { MonthCalendar } from "@/src/types/calendarTypes";
+import { DiaryResult, MonthCalendar } from "@/src/types/calendarTypes";
 import { ErrorResponse } from "@/src/types/commonTypes";
 import { isAxiosError } from "axios";
 
@@ -26,4 +26,12 @@ export const getCalendarFn = async (year: number, month: number) => {
     // 나머지 경우 에러는 던짐
     throw e;
   }
+};
+
+export const getDiaryFn = async (year: number, month: number, day: number) => {
+  const { data } = await axiosInstance.get<DiaryResult>(
+    `${endpoint.calendar.day}?year=${year}&month=${month}&day=${day}`
+  );
+  console.log(data);
+  return data;
 };

--- a/src/app/(app)/_layout.tsx
+++ b/src/app/(app)/_layout.tsx
@@ -1,5 +1,6 @@
 import { Stack } from "expo-router";
 import IsNewUserProvider from "@/src/contexts/IsNewUserProvider";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 
 /**
  * @description ContextProvider들로 감싸는 레이아웃
@@ -7,7 +8,9 @@ import IsNewUserProvider from "@/src/contexts/IsNewUserProvider";
 function ContextLayout() {
   return (
     <IsNewUserProvider>
-      <Stack screenOptions={{ headerShown: false }} />
+      <GestureHandlerRootView>
+        <Stack screenOptions={{ headerShown: false }} />
+      </GestureHandlerRootView>
     </IsNewUserProvider>
   );
 }

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -55,6 +55,7 @@ const colors = {
   settingText: "#121212",
   settingSubText: "#AAAAAA",
   settingValueText: "#505050",
+  diaryText: "#242424",
 };
 
 const gap = {

--- a/src/hooks/useCurrentDate.ts
+++ b/src/hooks/useCurrentDate.ts
@@ -1,9 +1,11 @@
-import { getCalendarFn } from "@/src/apis/calendarApi";
+import { getCalendarFn, getDiaryFn } from "@/src/apis/calendarApi";
 import { getNextDate, getPrevDate } from "@/src/utils/calculateDate";
-import { useQueries } from "@tanstack/react-query";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
 const useCurrentDate = () => {
+  const queryClient = useQueryClient();
+
   const [curYear, setCurYear] = useState<number>(() => new Date().getFullYear());
   const [curMonth, setCurMonth] = useState<number>(() => new Date().getMonth() + 1);
 
@@ -11,6 +13,7 @@ const useCurrentDate = () => {
   const [nextYear, nextMonth] = getNextDate(curYear, curMonth);
 
   // 캘린더는 현재 월 && 일기 쓰고 나온 뒤, 요약 생성이 끝났을 때를 제외하면 데이터가 변할 일이 없으므로 staleTime을 길게 잡아보자
+  // 일기 데이터 역시 변할 일이 거의 없으므로 staleTime 길게!
   const diariesData = useQueries({
     queries: [
       {
@@ -29,9 +32,26 @@ const useCurrentDate = () => {
         staleTime: 5 * 60 * 1000,
       },
     ],
-    // 3개월 데이터를 flat시킴
-    combine: (result) =>
-      result.filter((query) => query.isSuccess).flatMap((query) => query.data.result),
+    combine: (result) => {
+      // 3개월 캘린더 데이터를 flat
+      const flattedData = result
+        .filter((query) => query.isSuccess)
+        .flatMap((query) => query.data.result);
+
+      // 현재 월 일기 데이터를 미리 prefetch <- 만약 한 달에 30번이나 일기 꼬박꼬박 썼으면 30개의 병렬 API 호출: 백엔드/DB 부하 커지려나?
+      // 차라리 일기 데이터를 1달 단위로 받는게 나으려나...
+      const curMonthData = flattedData.filter((data) => data.month === curMonth);
+      curMonthData.map(({ year, month, day }) =>
+        queryClient.prefetchQuery({
+          queryFn: () => getDiaryFn(year, month, day),
+          queryKey: ["diary", year, month, day],
+          staleTime: 5 * 60 * 1000,
+        })
+      );
+
+      // 3개월 캘린더 데이터를 flat시켜 반환
+      return flattedData;
+    },
   });
 
   useEffect(() => {

--- a/src/hooks/useCurrentDate.ts
+++ b/src/hooks/useCurrentDate.ts
@@ -14,7 +14,7 @@ const useCurrentDate = () => {
 
   // 캘린더는 현재 월 && 일기 쓰고 나온 뒤, 요약 생성이 끝났을 때를 제외하면 데이터가 변할 일이 없으므로 staleTime을 길게 잡아보자
   // 일기 데이터 역시 변할 일이 거의 없으므로 staleTime 길게!
-  const diariesData = useQueries({
+  const calendarsData = useQueries({
     queries: [
       {
         queryFn: () => getCalendarFn(curYear, curMonth),
@@ -63,7 +63,7 @@ const useCurrentDate = () => {
     setCurMonth(month);
   };
 
-  return { diariesData, changeDate };
+  return { calendarsData, changeDate };
 };
 
 export default useCurrentDate;

--- a/src/pages/Calendar/ChatButton/styles.ts
+++ b/src/pages/Calendar/ChatButton/styles.ts
@@ -1,12 +1,12 @@
 import styled from "styled-components/native";
 import { Image } from "expo-image";
-import responsiveToPx from "@/src/utils/responsiveToPx";
+import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 
 export const Btn = styled.TouchableOpacity`
   width: ${responsiveToPx("60px")};
   height: ${responsiveToPx("60px")};
   position: absolute;
-  bottom: ${responsiveToPx("100px")};
+  bottom: ${responsiveToPxByHeight("70px")};
   left: 50%;
   border-radius: 9999px;
   transform: translateX(-${responsiveToPx("30px")});

--- a/src/pages/Calendar/DayComponent/index.tsx
+++ b/src/pages/Calendar/DayComponent/index.tsx
@@ -4,18 +4,19 @@ import * as S from "./styles";
 
 interface Props {
   date: DateData;
-  diaries?: Day[];
+  calendars?: Day[];
   onPress: () => void;
 }
 
-function DayComponent({ date, diaries }: Props): JSX.Element {
-  const dayDiary = diaries?.find(
-    (diary) => diary.year === date.year && diary.month === date.month && diary.day === date.day
+function DayComponent({ date, calendars, onPress }: Props): JSX.Element {
+  const dayDiary = calendars?.find(
+    (calendar) =>
+      calendar.year === date.year && calendar.month === date.month && calendar.day === date.day
   );
 
   if (!dayDiary) {
     return (
-      <S.DayBox>
+      <S.DayBox disabled={true}>
         <S.ImageBox>
           <S.DayText>{date.day}</S.DayText>
         </S.ImageBox>
@@ -24,7 +25,7 @@ function DayComponent({ date, diaries }: Props): JSX.Element {
   }
 
   return (
-    <S.DayBox>
+    <S.DayBox onPress={onPress}>
       <S.ImageBox>
         <S.Image src={dayDiary.imageS3} />
       </S.ImageBox>

--- a/src/pages/Calendar/DayComponent/styles.ts
+++ b/src/pages/Calendar/DayComponent/styles.ts
@@ -1,15 +1,15 @@
 import styled from "styled-components/native";
 import { Image as Img } from "react-native";
-import responsiveToPx from "@/src/utils/responsiveToPx";
+import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 
 export const DayBox = styled.TouchableOpacity`
-  width: ${responsiveToPx("54px")};
-  height: ${responsiveToPx("96px")};
+  width: ${responsiveToPxByHeight("54px")};
+  height: ${responsiveToPxByHeight("96px")};
 `;
 
 export const ImageBox = styled.View`
-  width: ${responsiveToPx("54px")};
-  height: ${responsiveToPx("54px")};
+  width: ${responsiveToPxByHeight("54px")};
+  height: ${responsiveToPxByHeight("54px")};
   border-radius: ${({ theme }) => theme.borderRadius.sm};
   justify-content: center;
   align-items: center;
@@ -17,15 +17,15 @@ export const ImageBox = styled.View`
 `;
 
 export const Image = styled(Img)`
-  width: ${responsiveToPx("54px")};
-  height: ${responsiveToPx("54px")};
+  width: ${responsiveToPxByHeight("54px")};
+  height: ${responsiveToPxByHeight("54px")};
 `;
 
 export const TagBox = styled.View`
   background-color: ${({ theme }) => theme.colors.skyBlue};
-  width: ${responsiveToPx("54px")};
-  height: ${responsiveToPx("15px")};
-  margin-top: ${responsiveToPx("6px")};
+  width: ${responsiveToPxByHeight("54px")};
+  height: ${responsiveToPxByHeight("15px")};
+  margin-top: ${responsiveToPxByHeight("3px")};
   border-radius: ${({ theme }) => theme.borderRadius.xs};
   justify-content: center;
   padding-left: ${responsiveToPx("4px")};

--- a/src/pages/Calendar/DiaryBottomSheet/index.tsx
+++ b/src/pages/Calendar/DiaryBottomSheet/index.tsx
@@ -1,33 +1,70 @@
-import { useMemo, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Dispatch, SetStateAction, useEffect, useMemo, useRef } from "react";
 import BottomSheet, {
   BottomSheetBackdrop,
   BottomSheetBackdropProps,
   BottomSheetScrollView,
 } from "@gorhom/bottom-sheet";
+import { DateData } from "react-native-calendars";
+import { DiaryResult } from "@/src/types/calendarTypes";
 import * as S from "./styles";
 
+import { Text, View } from "react-native";
+
 interface Props {
-  year: string;
-  month: string;
-  day: string;
+  pressedDate: Pick<DateData, "year" | "month" | "day">;
+  isBottomSheetOpen: boolean;
+  setIsBottomSheetOpen: Dispatch<SetStateAction<boolean>>;
 }
 
-function DiaryBottomSheet({ year, month, day }: Props): JSX.Element {
+function DiaryBottomSheet({
+  pressedDate,
+  isBottomSheetOpen,
+  setIsBottomSheetOpen,
+}: Props): JSX.Element {
   const sheetRef = useRef<BottomSheet>(null);
-  const snapPoints = useMemo(() => ["30%", "50%", "70%"], []);
+  const snapPoints = useMemo(() => ["50%", "70%"], []);
+
+  // queryFn을 넣지 않으면, 캐시되지 않은 데이터는 불러오지 않는다
+  // 즉 오늘 날짜로 pressedDate가 잡혀있어 의미없는 api 요청이 하나 더 발생하지 않는다
+  const { data } = useQuery<DiaryResult>({
+    queryKey: ["diary", pressedDate.year, pressedDate.month, pressedDate.day],
+    staleTime: 5 * 60 * 1000,
+    enabled: isBottomSheetOpen,
+  });
+
+  useEffect(() => {
+    if (isBottomSheetOpen && sheetRef.current) {
+      sheetRef.current.expand();
+    }
+  }, [isBottomSheetOpen]);
+
+  const handleCloseBottomSheet = () => {
+    if (sheetRef.current) {
+      setIsBottomSheetOpen(false);
+      sheetRef.current.close();
+    }
+  };
+
+  console.log(data);
 
   return (
     <BottomSheet
       ref={sheetRef}
       index={-1}
       handleStyle={S.bottomSheetShadow}
+      handleIndicatorStyle={S.indicatorStyle}
       snapPoints={snapPoints}
       enableDynamicSizing={false}
       enablePanDownToClose={true}
       backdropComponent={Backdrop}
-      handleIndicatorStyle={S.indicatorStyle}
+      onClose={handleCloseBottomSheet}
     >
-      <BottomSheetScrollView></BottomSheetScrollView>
+      <BottomSheetScrollView>
+        <View style={{ flex: 1 }}>
+          <Text style={{ color: "black", fontSize: 64 }}>{data?.message}</Text>
+        </View>
+      </BottomSheetScrollView>
     </BottomSheet>
   );
 }

--- a/src/pages/Calendar/DiaryBottomSheet/index.tsx
+++ b/src/pages/Calendar/DiaryBottomSheet/index.tsx
@@ -1,22 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { ForwardedRef, forwardRef, useMemo } from "react";
-import BottomSheet, {
-  BottomSheetBackdrop,
-  BottomSheetBackdropProps,
-  BottomSheetScrollView,
-} from "@gorhom/bottom-sheet";
+import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps } from "@gorhom/bottom-sheet";
 import { DateData } from "react-native-calendars";
 import { DiaryResult } from "@/src/types/calendarTypes";
+import { shadowProps } from "@/src/constants/shadowProps";
 import * as S from "./styles";
-
-import { Text, View } from "react-native";
 
 interface Props {
   pressedDate: Pick<DateData, "year" | "month" | "day">;
 }
 
 function DiaryBottomSheet({ pressedDate }: Props, ref: ForwardedRef<BottomSheet>): JSX.Element {
-  const snapPoints = useMemo(() => ["20%", "50%", "80%"], []);
+  const snapPoints = useMemo(() => ["60%", "90%"], []);
 
   // queryFn을 넣지 않으면, 캐시되지 않은 데이터는 불러오지 않는다
   // 즉 오늘 날짜로 pressedDate가 잡혀있어 의미없는 api 요청이 하나 더 발생하지 않는다
@@ -25,7 +20,7 @@ function DiaryBottomSheet({ pressedDate }: Props, ref: ForwardedRef<BottomSheet>
     staleTime: 5 * 60 * 1000,
   });
 
-  console.log(data);
+  console.log(data?.result);
 
   return (
     <BottomSheet
@@ -38,13 +33,33 @@ function DiaryBottomSheet({ pressedDate }: Props, ref: ForwardedRef<BottomSheet>
       enablePanDownToClose={true}
       backdropComponent={Backdrop}
     >
-      <BottomSheetScrollView>
-        {data && (
-          <View style={{ flex: 1 }}>
-            <Text style={{ color: "black", fontSize: 64 }}>{data.message}</Text>
-          </View>
-        )}
-      </BottomSheetScrollView>
+      {data && (
+        <S.BottomSheetLayout>
+          <S.ScrollBox showsVerticalScrollIndicator={false}>
+            <S.ImageBox>
+              <S.Image source={{ uri: data.result.imageS3 }} />
+            </S.ImageBox>
+            <S.DateText>
+              {data.result.year}. {data.result.month}. {data.result.day}
+            </S.DateText>
+            <S.TitleText>{data.result.summaryTitle}</S.TitleText>
+            <S.ContentText>{data.result.summaryContent}</S.ContentText>
+
+            <S.TagText>#놀이공원 #롤러코스터</S.TagText>
+            <S.ChatButtonBox>
+              <S.ViewChatButton
+                hitSlop={10}
+                style={shadowProps}
+                onPress={() => {
+                  /* Todo: 버튼 클릭 시 채팅방 레이아웃에서 나눴던 채팅 읽기 */
+                }}
+              >
+                <S.ButtonText>전체 대화 보기</S.ButtonText>
+              </S.ViewChatButton>
+            </S.ChatButtonBox>
+          </S.ScrollBox>
+        </S.BottomSheetLayout>
+      )}
     </BottomSheet>
   );
 }

--- a/src/pages/Calendar/DiaryBottomSheet/index.tsx
+++ b/src/pages/Calendar/DiaryBottomSheet/index.tsx
@@ -1,0 +1,39 @@
+import { useMemo, useRef } from "react";
+import BottomSheet, {
+  BottomSheetBackdrop,
+  BottomSheetBackdropProps,
+  BottomSheetScrollView,
+} from "@gorhom/bottom-sheet";
+import * as S from "./styles";
+
+interface Props {
+  year: string;
+  month: string;
+  day: string;
+}
+
+function DiaryBottomSheet({ year, month, day }: Props): JSX.Element {
+  const sheetRef = useRef<BottomSheet>(null);
+  const snapPoints = useMemo(() => ["30%", "50%", "70%"], []);
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      index={-1}
+      handleStyle={S.bottomSheetShadow}
+      snapPoints={snapPoints}
+      enableDynamicSizing={false}
+      enablePanDownToClose={true}
+      backdropComponent={Backdrop}
+      handleIndicatorStyle={S.indicatorStyle}
+    >
+      <BottomSheetScrollView></BottomSheetScrollView>
+    </BottomSheet>
+  );
+}
+
+function Backdrop(props: BottomSheetBackdropProps) {
+  return <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={1} />;
+}
+
+export default DiaryBottomSheet;

--- a/src/pages/Calendar/DiaryBottomSheet/index.tsx
+++ b/src/pages/Calendar/DiaryBottomSheet/index.tsx
@@ -39,9 +39,11 @@ function DiaryBottomSheet({ pressedDate }: Props, ref: ForwardedRef<BottomSheet>
       backdropComponent={Backdrop}
     >
       <BottomSheetScrollView>
-        <View style={{ flex: 1 }}>
-          <Text style={{ color: "black", fontSize: 64 }}>{data?.message}</Text>
-        </View>
+        {data && (
+          <View style={{ flex: 1 }}>
+            <Text style={{ color: "black", fontSize: 64 }}>{data.message}</Text>
+          </View>
+        )}
       </BottomSheetScrollView>
     </BottomSheet>
   );

--- a/src/pages/Calendar/DiaryBottomSheet/index.tsx
+++ b/src/pages/Calendar/DiaryBottomSheet/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Dispatch, SetStateAction, useEffect, useMemo, useRef } from "react";
+import { ForwardedRef, forwardRef, useMemo } from "react";
 import BottomSheet, {
   BottomSheetBackdrop,
   BottomSheetBackdropProps,
@@ -13,44 +13,23 @@ import { Text, View } from "react-native";
 
 interface Props {
   pressedDate: Pick<DateData, "year" | "month" | "day">;
-  isBottomSheetOpen: boolean;
-  setIsBottomSheetOpen: Dispatch<SetStateAction<boolean>>;
 }
 
-function DiaryBottomSheet({
-  pressedDate,
-  isBottomSheetOpen,
-  setIsBottomSheetOpen,
-}: Props): JSX.Element {
-  const sheetRef = useRef<BottomSheet>(null);
-  const snapPoints = useMemo(() => ["50%", "70%"], []);
+function DiaryBottomSheet({ pressedDate }: Props, ref: ForwardedRef<BottomSheet>): JSX.Element {
+  const snapPoints = useMemo(() => ["20%", "50%", "80%"], []);
 
   // queryFn을 넣지 않으면, 캐시되지 않은 데이터는 불러오지 않는다
   // 즉 오늘 날짜로 pressedDate가 잡혀있어 의미없는 api 요청이 하나 더 발생하지 않는다
   const { data } = useQuery<DiaryResult>({
     queryKey: ["diary", pressedDate.year, pressedDate.month, pressedDate.day],
     staleTime: 5 * 60 * 1000,
-    enabled: isBottomSheetOpen,
   });
-
-  useEffect(() => {
-    if (isBottomSheetOpen && sheetRef.current) {
-      sheetRef.current.expand();
-    }
-  }, [isBottomSheetOpen]);
-
-  const handleCloseBottomSheet = () => {
-    if (sheetRef.current) {
-      setIsBottomSheetOpen(false);
-      sheetRef.current.close();
-    }
-  };
 
   console.log(data);
 
   return (
     <BottomSheet
-      ref={sheetRef}
+      ref={ref}
       index={-1}
       handleStyle={S.bottomSheetShadow}
       handleIndicatorStyle={S.indicatorStyle}
@@ -58,7 +37,6 @@ function DiaryBottomSheet({
       enableDynamicSizing={false}
       enablePanDownToClose={true}
       backdropComponent={Backdrop}
-      onClose={handleCloseBottomSheet}
     >
       <BottomSheetScrollView>
         <View style={{ flex: 1 }}>
@@ -73,4 +51,4 @@ function Backdrop(props: BottomSheetBackdropProps) {
   return <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={1} />;
 }
 
-export default DiaryBottomSheet;
+export default forwardRef(DiaryBottomSheet);

--- a/src/pages/Calendar/DiaryBottomSheet/styles.ts
+++ b/src/pages/Calendar/DiaryBottomSheet/styles.ts
@@ -1,3 +1,6 @@
+import styled from "styled-components/native";
+import { BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 import { theme } from "@/src/constants/theme";
 
 export const indicatorStyle = {
@@ -8,3 +11,73 @@ export const bottomSheetShadow = {
   boxShadow: "0 -2 10 0 #ffffff",
   borderRadius: "100%",
 };
+
+export const BottomSheetLayout = styled.View`
+  flex: 1;
+  padding: 0px ${responsiveToPx("25px")};
+`;
+
+export const ImageBox = styled.View`
+  width: ${responsiveToPx("380px")};
+  height: ${responsiveToPx("380px")};
+  border-radius: ${({ theme }) => theme.borderRadius.base};
+  overflow: hidden;
+`;
+
+export const Image = styled.Image`
+  width: 100%;
+  height: 100%;
+`;
+
+export const ScrollBox = styled(BottomSheetScrollView)``;
+
+export const DateText = styled.Text`
+  padding-top: ${responsiveToPx("13px")};
+  font-family: ${({ theme }) => theme.fontFamily.podkovaRegular};
+  font-size: ${({ theme }) => theme.fontSize.lg};
+  color: ${({ theme }) => theme.colors.black};
+`;
+
+export const TitleText = styled.Text`
+  padding-top: ${responsiveToPx("13px")};
+  font-family: ${({ theme }) => theme.fontFamily.nsBold};
+  font-size: ${({ theme }) => theme.fontSize.lg};
+  color: ${({ theme }) => theme.colors.black};
+`;
+
+export const ContentText = styled.Text`
+  padding-top: ${responsiveToPx("13px")};
+  font-family: ${({ theme }) => theme.fontFamily.nsRegular};
+  font-size: ${({ theme }) => theme.fontSize.base};
+  color: ${({ theme }) => theme.colors.diaryText};
+  line-height: ${responsiveToPxByHeight("24px")};
+`;
+
+export const TagText = styled.Text`
+  padding-top: ${responsiveToPx("13px")};
+  font-family: ${({ theme }) => theme.fontFamily.nsBold};
+  font-size: ${({ theme }) => theme.fontSize.base};
+  color: ${({ theme }) => theme.colors.deepGreen};
+`;
+
+export const ChatButtonBox = styled.View`
+  width: 100%;
+  padding: ${responsiveToPxByHeight("26px")};
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ViewChatButton = styled.TouchableOpacity`
+  width: ${responsiveToPx("173px")};
+  height: ${responsiveToPx("40px")};
+  border-radius: ${({ theme }) => theme.borderRadius.base};
+  background-color: ${({ theme }) => theme.colors.deepGreen};
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ButtonText = styled.Text`
+  color: ${({ theme }) => theme.colors.white};
+  font-family: ${({ theme }) => theme.fontFamily.nsBold};
+  font-size: ${({ theme }) => theme.fontSize.md};
+`;

--- a/src/pages/Calendar/DiaryBottomSheet/styles.ts
+++ b/src/pages/Calendar/DiaryBottomSheet/styles.ts
@@ -1,0 +1,10 @@
+import { theme } from "@/src/constants/theme";
+
+export const indicatorStyle = {
+  backgroundColor: theme.colors.settingSubText,
+};
+
+export const bottomSheetShadow = {
+  boxShadow: "0 -2 10 0 #ffffff",
+  borderRadius: "100%",
+};

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -32,7 +32,7 @@ LocaleConfig.defaultLocale = "ko";
 
 function CalendarPage(): JSX.Element {
   const router = useRouter();
-  const { diariesData, changeDate } = useCurrentDate();
+  const { calendarsData, changeDate } = useCurrentDate();
 
   const handleCopyPress = () => {
     console.log("copy button");
@@ -69,7 +69,11 @@ function CalendarPage(): JSX.Element {
         dayComponent={({ date }) => {
           if (!date) return undefined;
           return (
-            <DayComponent date={date} diaries={diariesData} onPress={() => handleDayPress(date)} />
+            <DayComponent
+              date={date}
+              calendars={calendarsData}
+              onPress={() => handleDayPress(date)}
+            />
           );
         }}
       />

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -4,6 +4,7 @@ import useCurrentDate from "@/src/hooks/useCurrentDate";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import DayComponent from "./DayComponent";
 import ChatButton from "./ChatButton";
+import DiaryBottomSheet from "./DiaryBottomSheet";
 import { theme } from "@/src/constants/theme";
 import * as S from "./styles";
 
@@ -73,6 +74,7 @@ function CalendarPage(): JSX.Element {
         }}
       />
       <ChatButton onPress={() => {}} />
+      <DiaryBottomSheet />
     </S.SafeView>
   );
 }

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -1,7 +1,8 @@
+import { useEffect, useState } from "react";
 import { useRouter } from "expo-router";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { CalendarList, DateData, LocaleConfig } from "react-native-calendars";
 import useCurrentDate from "@/src/hooks/useCurrentDate";
-import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import DayComponent from "./DayComponent";
 import ChatButton from "./ChatButton";
 import DiaryBottomSheet from "./DiaryBottomSheet";
@@ -31,6 +32,15 @@ LocaleConfig.locales["ko"] = {
 LocaleConfig.defaultLocale = "ko";
 
 function CalendarPage(): JSX.Element {
+  // BottomSheet를 열고 닫기 위해 전달할 state
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState<boolean>(false);
+  // 초기값은 오늘로
+  const [pressedDate, setPressedDate] = useState<Pick<DateData, "year" | "month" | "day">>(() => ({
+    year: new Date().getFullYear(),
+    month: new Date().getMonth() + 1,
+    day: new Date().getDate(),
+  }));
+
   const router = useRouter();
   const { calendarsData, changeDate } = useCurrentDate();
 
@@ -42,9 +52,15 @@ function CalendarPage(): JSX.Element {
     router.push("/(app)/setting");
   };
 
-  const handleDayPress = (day: DateData) => {
-    console.log("selected day", day);
+  const handleDayPress = (date: DateData) => {
+    const { year, month, day } = date;
+    setIsBottomSheetOpen(true);
+    setPressedDate({ year, month, day });
   };
+
+  useEffect(() => {
+    console.log(isBottomSheetOpen);
+  }, [isBottomSheetOpen]);
 
   return (
     <S.SafeView>
@@ -78,7 +94,11 @@ function CalendarPage(): JSX.Element {
         }}
       />
       <ChatButton onPress={() => {}} />
-      <DiaryBottomSheet />
+      <DiaryBottomSheet
+        pressedDate={pressedDate}
+        isBottomSheetOpen={isBottomSheetOpen}
+        setIsBottomSheetOpen={setIsBottomSheetOpen}
+      />
     </S.SafeView>
   );
 }

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "expo-router";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { CalendarList, DateData, LocaleConfig } from "react-native-calendars";
+import BottomSheet from "@gorhom/bottom-sheet";
 import useCurrentDate from "@/src/hooks/useCurrentDate";
 import DayComponent from "./DayComponent";
 import ChatButton from "./ChatButton";
@@ -32,8 +33,6 @@ LocaleConfig.locales["ko"] = {
 LocaleConfig.defaultLocale = "ko";
 
 function CalendarPage(): JSX.Element {
-  // BottomSheet를 열고 닫기 위해 전달할 state
-  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState<boolean>(false);
   // 초기값은 오늘로
   const [pressedDate, setPressedDate] = useState<Pick<DateData, "year" | "month" | "day">>(() => ({
     year: new Date().getFullYear(),
@@ -43,6 +42,7 @@ function CalendarPage(): JSX.Element {
 
   const router = useRouter();
   const { calendarsData, changeDate } = useCurrentDate();
+  const bottomSheetRef = useRef<BottomSheet>(null); // BottomSheet(자식 컴포넌트)를 조작하기 위한 부모 ref
 
   const handleCopyPress = () => {
     console.log("copy button");
@@ -54,13 +54,11 @@ function CalendarPage(): JSX.Element {
 
   const handleDayPress = (date: DateData) => {
     const { year, month, day } = date;
-    setIsBottomSheetOpen(true);
     setPressedDate({ year, month, day });
+    if (bottomSheetRef.current) {
+      bottomSheetRef.current.expand();
+    }
   };
-
-  useEffect(() => {
-    console.log(isBottomSheetOpen);
-  }, [isBottomSheetOpen]);
 
   return (
     <S.SafeView>
@@ -94,11 +92,7 @@ function CalendarPage(): JSX.Element {
         }}
       />
       <ChatButton onPress={() => {}} />
-      <DiaryBottomSheet
-        pressedDate={pressedDate}
-        isBottomSheetOpen={isBottomSheetOpen}
-        setIsBottomSheetOpen={setIsBottomSheetOpen}
-      />
+      <DiaryBottomSheet ref={bottomSheetRef} pressedDate={pressedDate} />
     </S.SafeView>
   );
 }

--- a/src/types/calendarTypes.ts
+++ b/src/types/calendarTypes.ts
@@ -12,3 +12,25 @@ export type Day = {
 export type MonthCalendar = SuccessResponse & {
   result: Day[];
 };
+
+export type DiaryResult = SuccessResponse & {
+  result: {
+    year: number;
+    month: number;
+    day: number;
+    imageS3: string;
+    summaryTitle: string;
+    summaryContent: string;
+    summaryMood:
+      | "HAPPY"
+      | "SAD"
+      | "TIRED"
+      | "ANGRY"
+      | "RELAX"
+      | "HAPPY"
+      | "SAD"
+      | "TIRED"
+      | "ANGRY"
+      | "RELAX";
+  };
+};


### PR DESCRIPTION
# 개요

- 사용자가 캘린더에서 일기 바텀 시트를 열 때 로딩 시간을 없애기 위해 현재 화면에 렌더링되는 달의 일기 데이터를 미리 `prefetch`하도록 설계
- 이미 작성된 일기는 수정이 발생하지 않으므로, `staleTime`을 5분으로 지정해 HTTP 재요청 방지

---

## 구현

- [X] 기기 세로/가로 비율에 따라 일부 기기의 캘린더가 너무 큰 문제 해결 (캘린더에는 기기 세로 비율 반응형 px 적용)
- [X] 팝업을 구현하기 위한 적절한 라이브러리를 찾고, 초기 세팅 하기 [react-native-bottom-sheet](https://github.com/gorhom/react-native-bottom-sheet)
- [X] 팝업에 들어갈 데이터를 가져오는 `queryFn`과 `useQuery` 구현
- [X] 로딩 시간을 없애기 위해 팝업에 들어갈 데이터를 `useCurrentDate`(캘린더 useQuery 훅)에서 현재 달만 미리 `prefetch` 하도록 구현 (한달에 30개의 일기가 있으면, 30개의 병렬 API 요청이 발생해 백엔드 부하 예상 -> 회의를 통해 1달치 일기를 받는 API 추가하기로 결정)
- [X] 일기가 써져있는 날짜들은 클릭 시 바텀 시트가 올라오도록 구현, 일기가 없는 날짜는 클릭 불가능하게 막음
    - [X] 바텀 시트를 내리고, 바로 캘린더의 날짜를 누르면 터치가 씹히는 문제 발견 → `state`로 바텀 시트 상태를 조절해서 발생하는 문제로 인식 (상태가 늦게 변해서 클릭을 씹음) → `forwardRef`를 통해 부모가 직접 `ref`로 접근해 `expand()` 시키도록 수정해 해결 (아이디어: [react-native-reanimated documentation](https://docs.swmansion.com/react-native-reanimated/examples/bottomsheet/) 만져보는데 얘는 렉이 없어 ref로 조작해보게 됨)
- [X] 일기 팝업에 데이터를 가져와 Figma 디자인대로 구현

---

## 구현 결과

https://github.com/user-attachments/assets/e9d12d22-b67d-4b51-8973-966b7846775a

---