### PR TITLE
채팅 페이지 구현

### DIFF
--- a/src/apis/threadApi.ts
+++ b/src/apis/threadApi.ts
@@ -21,3 +21,15 @@ export const getMessagesFn = async ({ year, month, day }: ThreadDate) => {
   console.log(data);
   return data;
 };
+
+export const changeAiFn = async ({
+  aiProfileId,
+  year,
+  month,
+  day,
+}: ThreadDate & { aiProfileId: number }) => {
+  const { data } = await axiosInstance.patch(
+    `${endpoint.thread.changeAi}?aiProfileId=${aiProfileId}&year=${year}&month=${month}&day=${day}`
+  );
+  return data;
+};

--- a/src/apis/threadApi.ts
+++ b/src/apis/threadApi.ts
@@ -1,6 +1,6 @@
 import axiosInstance from "@/src/libs/axiosInstance";
 import endpoint from "@/src/constants/endpoint";
-import { NewThreadResult, ThreadDate } from "@/src/types/threadTypes";
+import { MessageResult, NewThreadResult, ThreadDate } from "@/src/types/threadTypes";
 
 export const newThreadFn = async ({
   aiProfileId,
@@ -15,7 +15,7 @@ export const newThreadFn = async ({
 };
 
 export const getMessagesFn = async ({ year, month, day }: ThreadDate) => {
-  const { data } = await axiosInstance.get(
+  const { data } = await axiosInstance.get<MessageResult>(
     `${endpoint.thread.chat}?year=${year}&month=${month}&day=${day}`
   );
   console.log(data);

--- a/src/apis/threadApi.ts
+++ b/src/apis/threadApi.ts
@@ -1,0 +1,17 @@
+import axiosInstance from "@/src/libs/axiosInstance";
+import endpoint from "@/src/constants/endpoint";
+import { NewThreadResult } from "@/src/types/threadTypes";
+
+type NewThreadFnType = {
+  aiProfileId: number;
+  year: number;
+  month: number;
+  day: number;
+};
+
+export const newThreadFn = async ({ aiProfileId, year, month, day }: NewThreadFnType) => {
+  const { data } = await axiosInstance.post<NewThreadResult>(
+    `${endpoint.thread.chat}?aiProfileId=${aiProfileId}&year=${year}&month=${month}&day=${day}`
+  );
+  return data;
+};

--- a/src/apis/threadApi.ts
+++ b/src/apis/threadApi.ts
@@ -1,17 +1,23 @@
 import axiosInstance from "@/src/libs/axiosInstance";
 import endpoint from "@/src/constants/endpoint";
-import { NewThreadResult } from "@/src/types/threadTypes";
+import { NewThreadResult, ThreadDate } from "@/src/types/threadTypes";
 
-type NewThreadFnType = {
-  aiProfileId: number;
-  year: number;
-  month: number;
-  day: number;
-};
-
-export const newThreadFn = async ({ aiProfileId, year, month, day }: NewThreadFnType) => {
+export const newThreadFn = async ({
+  aiProfileId,
+  year,
+  month,
+  day,
+}: ThreadDate & { aiProfileId: number }) => {
   const { data } = await axiosInstance.post<NewThreadResult>(
     `${endpoint.thread.chat}?aiProfileId=${aiProfileId}&year=${year}&month=${month}&day=${day}`
   );
+  return data;
+};
+
+export const getMessagesFn = async ({ year, month, day }: ThreadDate) => {
+  const { data } = await axiosInstance.get(
+    `${endpoint.thread.chat}?year=${year}&month=${month}&day=${day}`
+  );
+  console.log(data);
   return data;
 };

--- a/src/app/(app)/chatting.tsx
+++ b/src/app/(app)/chatting.tsx
@@ -1,0 +1,7 @@
+import ChattingPage from "@/src/pages/Chatting";
+
+function ChattingRouter(): JSX.Element {
+  return <ChattingPage />;
+}
+
+export default ChattingRouter;

--- a/src/app/(app)/chatting.tsx
+++ b/src/app/(app)/chatting.tsx
@@ -1,7 +1,80 @@
+import { useCallback, useEffect, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import CommonError from "@/src/components/ui/CommonError";
+import Loading from "@/src/components/ui/Loading";
 import ChattingPage from "@/src/pages/Chatting";
+import useUserSetting from "@/src/hooks/useUserSetting";
+import { newThreadFn } from "@/src/apis/threadApi";
+import { getAiProfileId } from "@/src/libs/mmkv";
+import { getThreadDateExpired } from "@/src/utils/time";
+import { ThreadDate } from "@/src/types/threadTypes";
 
-function ChattingRouter(): JSX.Element {
-  return <ChattingPage />;
+function ChattingRouter(): JSX.Element | null {
+  const [threadDate, setThreadDate] = useState<ThreadDate | null>(null); // 스레드 생성 년월일 state
+  const [expiredDate, setExpiredDate] = useState<Date | null>(null); // 스레드 제거 시점 Date 객체
+  const { isPending, isError, data, refetch } = useUserSetting(); // 사용자 설정 로드
+  const {
+    isPending: isMutatePending,
+    isError: isMutateError,
+    mutate,
+  } = useMutation({
+    mutationFn: newThreadFn,
+    onSuccess: ({ result }) => {
+      console.log(result);
+      setThreadDate({ year: result.year, month: result.month, day: result.day });
+    },
+    onError: (error) => console.error(error.response?.data),
+  });
+
+  const handleMutate = useCallback(
+    (sleepTime: string) => {
+      const aiProfileId = getAiProfileId();
+      if (aiProfileId) {
+        const sleepHour = parseInt(sleepTime.slice(0, 2));
+        const [{ year, month, day }, threadExpiredDate] = getThreadDateExpired(sleepHour);
+        setExpiredDate(threadExpiredDate);
+        mutate({
+          aiProfileId,
+          year,
+          month,
+          day,
+        });
+      }
+    },
+    [mutate]
+  );
+
+  useEffect(() => {
+    if (data) {
+      handleMutate(data.result.sleepTime);
+    }
+  }, [data, handleMutate]);
+
+  if (isPending || isMutatePending) {
+    return <Loading />;
+  }
+
+  if (isError) {
+    return (
+      <CommonError
+        titleText="자는 시간 로딩 중 에러 발생"
+        buttonText="다시 시도"
+        onPress={refetch}
+      />
+    );
+  }
+
+  if (isMutateError || !threadDate || !expiredDate) {
+    return (
+      <CommonError
+        titleText="대화방 생성 중 에러 발생"
+        buttonText="다시 시도"
+        onPress={() => handleMutate(data.result.sleepTime)}
+      />
+    );
+  }
+
+  return <ChattingPage threadDate={threadDate} expiredDate={expiredDate} />;
 }
 
 export default ChattingRouter;

--- a/src/app/(app)/chatting.tsx
+++ b/src/app/(app)/chatting.tsx
@@ -57,8 +57,8 @@ function ChattingRouter(): JSX.Element | null {
   if (isError) {
     return (
       <CommonError
-        titleText="자는 시간 로딩 중 에러 발생"
-        buttonText="다시 시도"
+        titleText="자는 시간을 불러오지 못했어요"
+        buttonText="다시 불러오기"
         onPress={refetch}
       />
     );
@@ -67,8 +67,8 @@ function ChattingRouter(): JSX.Element | null {
   if (isMutateError || !threadDate || !expiredDate) {
     return (
       <CommonError
-        titleText="대화방 생성 중 에러 발생"
-        buttonText="다시 시도"
+        titleText="대화방 생성에 실패했어요"
+        buttonText="다시 시도하기"
         onPress={() => handleMutate(data.result.sleepTime)}
       />
     );

--- a/src/app/(app)/chatting.tsx
+++ b/src/app/(app)/chatting.tsx
@@ -1,30 +1,21 @@
 import { useCallback, useEffect, useState } from "react";
-import { useMutation } from "@tanstack/react-query";
 import CommonError from "@/src/components/ui/CommonError";
 import Loading from "@/src/components/ui/Loading";
+import AssistantList from "@/src/components/AssistantList";
 import ChattingPage from "@/src/pages/Chatting";
+import { FlexView } from "@/src/pages/Chatting/styles";
 import useUserSetting from "@/src/hooks/useUserSetting";
-import { newThreadFn } from "@/src/apis/threadApi";
-import { getAiProfileId } from "@/src/libs/mmkv";
+import useMakeThread from "@/src/hooks/useMakeThread";
+import { getAiProfileId, setAiProfileId } from "@/src/libs/mmkv";
 import { getThreadDateExpired } from "@/src/utils/time";
 import { ThreadDate } from "@/src/types/threadTypes";
 
 function ChattingRouter(): JSX.Element | null {
+  const [isVisible, setIsVisible] = useState<boolean>(false);
   const [threadDate, setThreadDate] = useState<ThreadDate | null>(null); // 스레드 생성 년월일 state
   const [expiredDate, setExpiredDate] = useState<Date | null>(null); // 스레드 제거 시점 Date 객체
   const { isPending, isError, data, refetch } = useUserSetting(); // 사용자 설정 로드
-  const {
-    isPending: isMutatePending,
-    isError: isMutateError,
-    mutate,
-  } = useMutation({
-    mutationFn: newThreadFn,
-    onSuccess: ({ result }) => {
-      console.log(result);
-      setThreadDate({ year: result.year, month: result.month, day: result.day });
-    },
-    onError: (error) => console.error(error.response?.data),
-  });
+  const { isPending: isMutatePending, isError: isMutateError, mutate } = useMakeThread();
 
   const handleMutate = useCallback(
     (sleepTime: string) => {
@@ -33,6 +24,7 @@ function ChattingRouter(): JSX.Element | null {
         const sleepHour = parseInt(sleepTime.slice(0, 2));
         const [{ year, month, day }, threadExpiredDate] = getThreadDateExpired(sleepHour);
         setExpiredDate(threadExpiredDate);
+        setThreadDate({ year, month, day });
         mutate({
           aiProfileId,
           year,
@@ -64,7 +56,27 @@ function ChattingRouter(): JSX.Element | null {
     );
   }
 
-  if (isMutateError || !threadDate || !expiredDate) {
+  if (!threadDate || !expiredDate) {
+    return (
+      <FlexView>
+        <AssistantList
+          isVisible={isVisible}
+          setIsVisible={setIsVisible}
+          onPressAiCard={(aiProfileId) => {
+            setAiProfileId(aiProfileId);
+            handleMutate(data.result.sleepTime);
+          }}
+        />
+        <CommonError
+          titleText="서포터를 선택해주세요"
+          buttonText="선택하기"
+          onPress={() => setIsVisible(true)}
+        />
+      </FlexView>
+    );
+  }
+
+  if (isMutateError) {
     return (
       <CommonError
         titleText="대화방 생성에 실패했어요"

--- a/src/app/(app)/setting.tsx
+++ b/src/app/(app)/setting.tsx
@@ -1,18 +1,13 @@
-import { getUserSettingFn } from "@/src/apis/settingApi";
+import useUserSetting from "@/src/hooks/useUserSetting";
 import CommonError from "@/src/components/ui/CommonError";
 import Loading from "@/src/components/ui/Loading";
 import SettingPage from "@/src/pages/Setting";
-import { useQuery } from "@tanstack/react-query";
 
 /**
  * @description 유저 설정 페이지 라우터
  */
 function SettingRouter(): JSX.Element {
-  const { isPending, isError, data, refetch } = useQuery({
-    queryFn: getUserSettingFn,
-    queryKey: ["user-setting"],
-    staleTime: 5 * 60 * 1000,
-  });
+  const { isPending, isError, data, refetch } = useUserSetting();
 
   if (isPending) {
     return <Loading />;

--- a/src/components/AssistantList/AssistantCard/index.tsx
+++ b/src/components/AssistantList/AssistantCard/index.tsx
@@ -10,9 +10,10 @@ import * as S from "./styles";
 
 interface Props {
   item: AiProfileListWithGenerateAiTrigger;
+  onPressAiCard: (aiProfileId: number) => void;
 }
 
-function AssistantCard({ item }: Props) {
+function AssistantCard({ item, onPressAiCard }: Props) {
   const router = useRouter();
   const { mutate: removeMutate } = useRemoveAssistant();
 
@@ -35,11 +36,9 @@ function AssistantCard({ item }: Props) {
   const { aiProfileId, profileName, imageUrl, hashTag1, hashTag2, feature1, feature2, feature3 } =
     item;
 
-  // Todo: 채팅방 구현 후, 어시스턴트 캐러셀에서 클릭하면 대화 대상 변경되도록 구현
-
   return (
     <TouchableWithoutFeedback>
-      <S.ItemBox>
+      <S.ItemBox onPress={() => onPressAiCard(aiProfileId)}>
         <ProfileImage url={imageUrl} />
         <NameTag name={profileName} tag1={hashTag1} tag2={hashTag2} />
         <Personality feat1={feature1} feat2={feature2} feat3={feature3} />

--- a/src/components/AssistantList/index.tsx
+++ b/src/components/AssistantList/index.tsx
@@ -1,9 +1,8 @@
 import { Dispatch, SetStateAction, useState } from "react";
-import { Dimensions, TouchableWithoutFeedback } from "react-native";
+import { ActivityIndicator, Dimensions, TouchableWithoutFeedback } from "react-native";
 import { useQuery } from "@tanstack/react-query";
 import Carousel from "react-native-reanimated-carousel";
 import { assistantListFn } from "@/src/apis/aiProfileApi";
-import Loading from "@/src/components/ui/Loading";
 import Button from "@/src/components/ui/Button";
 import AssistantCard from "./AssistantCard";
 import * as S from "./styles";
@@ -11,9 +10,10 @@ import * as S from "./styles";
 interface Props {
   isVisible: boolean;
   setIsVisible: Dispatch<SetStateAction<boolean>>;
+  onPressAiCard: (aiProfileId: number) => void;
 }
 
-function AssistantList({ isVisible, setIsVisible }: Props): JSX.Element | null {
+function AssistantList({ isVisible, setIsVisible, onPressAiCard }: Props): JSX.Element | null {
   const [width] = useState<number>(() => Dimensions.get("window").width);
 
   const { isPending, isError, error, data, refetch } = useQuery({
@@ -31,7 +31,7 @@ function AssistantList({ isVisible, setIsVisible }: Props): JSX.Element | null {
       return (
         <S.AssistantListLayout onPress={handleOuterClick}>
           <S.ItemLayout>
-            <Loading />
+            <ActivityIndicator size="large" />
           </S.ItemLayout>
         </S.AssistantListLayout>
       );
@@ -71,7 +71,7 @@ function AssistantList({ isVisible, setIsVisible }: Props): JSX.Element | null {
           snapEnabled={true}
           renderItem={({ item }) => (
             <S.ItemLayout>
-              <AssistantCard item={item} />
+              <AssistantCard item={item} onPressAiCard={onPressAiCard} />
             </S.ItemLayout>
           )}
         />

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -56,6 +56,7 @@ const colors = {
   settingSubText: "#AAAAAA",
   settingValueText: "#505050",
   diaryText: "#242424",
+  placeholderText: "#979797",
 };
 
 const gap = {

--- a/src/constants/toastMessage.ts
+++ b/src/constants/toastMessage.ts
@@ -26,6 +26,7 @@ const toastMessage = {
     success: "서포터가 변경되었습니다.",
     failed: "서포터 변경에 실패했습니다. 잠시 후 다시 시도해주세요.",
   },
+  threadExpired: "이전 대화를 요약하고, 새로운 채팅방을 생성합니다.",
 };
 
 export default toastMessage;

--- a/src/constants/toastMessage.ts
+++ b/src/constants/toastMessage.ts
@@ -22,6 +22,10 @@ const toastMessage = {
     success: "서포터가 삭제되었습니다.",
     failed: "서포터 삭제에 실패했습니다. 다시 시도해주세요.",
   },
+  changeAssistant: {
+    success: "서포터가 변경되었습니다.",
+    failed: "서포터 변경에 실패했습니다. 잠시 후 다시 시도해주세요.",
+  },
 };
 
 export default toastMessage;

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -16,6 +16,7 @@ const useLogout = () => {
       console.log(data);
       await removeSecureValue("refreshToken");
       removeStorageValue("accessToken");
+      removeStorageValue("aiProfileId");
       queryClient.clear(); // 로그아웃 후 다른 계정에 접속해도 캐시가 남아있는 문제 존재했음. 깜빡했다...
       router.replace("/login");
     },

--- a/src/hooks/useMakeThread.ts
+++ b/src/hooks/useMakeThread.ts
@@ -1,0 +1,20 @@
+import { getMessagesFn, newThreadFn } from "@/src/apis/threadApi";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const useMakeThread = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: newThreadFn,
+    onSuccess: ({ result }) => {
+      console.log(result);
+      queryClient.prefetchQuery({
+        queryFn: () => getMessagesFn({ year: result.year, month: result.month, day: result.day }),
+        queryKey: ["message", { year: result.year, month: result.month, day: result.day }],
+      });
+    },
+    onError: (error) => console.error(error.response),
+  });
+};
+
+export default useMakeThread;

--- a/src/hooks/useUserSetting.ts
+++ b/src/hooks/useUserSetting.ts
@@ -1,0 +1,12 @@
+import { getUserSettingFn } from "@/src/apis/settingApi";
+import { useQuery } from "@tanstack/react-query";
+
+const useUserSetting = () => {
+  return useQuery({
+    queryFn: getUserSettingFn,
+    queryKey: ["user-setting"],
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+export default useUserSetting;

--- a/src/libs/axiosInstance.ts
+++ b/src/libs/axiosInstance.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse } from "axios";
 import { router } from "expo-router";
-import { getStorageValue, setStorageValue, removeStorageValue } from "./mmkv";
-import { getSecureValue, removeSecureValue, setSecureValue } from "./secureStorage";
+import { setStorageValue, removeStorageValue, getAccessToken } from "./mmkv";
+import { getRefreshToken, removeSecureValue, setSecureValue } from "./secureStorage";
 import endpoint from "../constants/endpoint";
 import { LoginType } from "../types/loginTypes";
 import { AxiosErrorToInterceptors, ErrorResponse } from "../types/commonTypes";
@@ -44,7 +44,7 @@ const axiosInstance = axios.create({
  * access token이 mmkv에 있으면 헤더에 추가하는 request interceptors
  */
 axiosInstance.interceptors.request.use((config) => {
-  const accessToken = getStorageValue("accessToken");
+  const accessToken = getAccessToken();
   if (accessToken) config.headers.Authorization = accessToken;
   return config;
 });
@@ -81,7 +81,7 @@ axiosInstance.interceptors.response.use(
       try {
         console.log("토큰 재발급 시작", config.url);
         isRefreshing = true;
-        const refreshToken = await getSecureValue("refreshToken");
+        const refreshToken = await getRefreshToken();
         if (!refreshToken) {
           console.error("refresh token이 존재하지 않아 재발급 종료 (아마 앱 최초 설치)");
           removeSecureValue("refreshToken");

--- a/src/libs/mmkv.ts
+++ b/src/libs/mmkv.ts
@@ -15,8 +15,12 @@ export const removeStorageValue = (key: string): void => {
 };
 
 export const getAiProfileId = (): number | null => {
-  const aiProfileId = storage.getString("aiProfileId");
-  return aiProfileId ? parseInt(aiProfileId) : null;
+  const aiProfileId = storage.getNumber("aiProfileId");
+  return aiProfileId ? aiProfileId : null;
+};
+
+export const setAiProfileId = (aiProfileId: number): void => {
+  storage.set("aiProfileId", aiProfileId);
 };
 
 export const getAccessToken = (): string | null => {

--- a/src/libs/mmkv.ts
+++ b/src/libs/mmkv.ts
@@ -13,3 +13,13 @@ export const getStorageValue = (key: string): string | null => {
 export const removeStorageValue = (key: string): void => {
   storage.delete(key);
 };
+
+export const getAiProfileId = (): number | null => {
+  const aiProfileId = storage.getString("aiProfileId");
+  return aiProfileId ? parseInt(aiProfileId) : null;
+};
+
+export const getAccessToken = (): string | null => {
+  const accessToken = storage.getString("accessToken");
+  return accessToken ? accessToken : null;
+};

--- a/src/libs/secureStorage.ts
+++ b/src/libs/secureStorage.ts
@@ -26,3 +26,12 @@ export const removeSecureValue = async (key: string): Promise<void> => {
     console.error("secureStore에서", key, "삭제 실패", e);
   }
 };
+
+export const getRefreshToken = async (): Promise<string | null> => {
+  try {
+    return await SecureStore.getItemAsync("refreshToken");
+  } catch (e) {
+    console.error("secureStore에서 refresh token 가져오지 못 함", e);
+    return null;
+  }
+};

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -52,6 +52,10 @@ function CalendarPage(): JSX.Element {
     router.push("/(app)/setting");
   };
 
+  const handleChattingPress = () => {
+    router.push("/(app)/chatting");
+  };
+
   const handleDayPress = (date: DateData) => {
     const { year, month, day } = date;
     setPressedDate({ year, month, day });
@@ -91,7 +95,7 @@ function CalendarPage(): JSX.Element {
           );
         }}
       />
-      <ChatButton onPress={() => {}} />
+      <ChatButton onPress={handleChattingPress} />
       <DiaryBottomSheet ref={bottomSheetRef} pressedDate={pressedDate} />
     </S.SafeView>
   );

--- a/src/pages/Chatting/AiChatBox/index.tsx
+++ b/src/pages/Chatting/AiChatBox/index.tsx
@@ -1,0 +1,20 @@
+import { shadowProps } from "@/src/constants/shadowProps";
+import * as S from "./styles";
+
+interface Props {
+  content: string;
+  imageUrl: string;
+}
+
+function AiChatBox({ content, imageUrl }: Props): JSX.Element {
+  return (
+    <S.AiChatLayout>
+      <S.Image source={{ uri: imageUrl }} />
+      <S.AiChatBox style={shadowProps}>
+        <S.AiChatText>{content}</S.AiChatText>
+      </S.AiChatBox>
+    </S.AiChatLayout>
+  );
+}
+
+export default AiChatBox;

--- a/src/pages/Chatting/AiChatBox/styles.ts
+++ b/src/pages/Chatting/AiChatBox/styles.ts
@@ -1,15 +1,15 @@
-import responsiveToPx from "@/src/utils/responsiveToPx";
+import { Image as Img } from "react-native";
 import styled from "styled-components/native";
+import responsiveToPx from "@/src/utils/responsiveToPx";
 
 export const AiChatLayout = styled.View`
   flex-direction: row;
   align-items: center;
-  margin-top: ${responsiveToPx("20px")};
-  margin-left: ${responsiveToPx("15px")};
+  margin: ${responsiveToPx("12px")} ${responsiveToPx("10px")};
   gap: ${({ theme }) => theme.gap.md};
 `;
 
-export const Image = styled.Image`
+export const Image = styled(Img)`
   width: ${responsiveToPx("36px")};
   height: ${responsiveToPx("36px")};
   border-radius: 9999px;

--- a/src/pages/Chatting/AiChatBox/styles.ts
+++ b/src/pages/Chatting/AiChatBox/styles.ts
@@ -1,0 +1,31 @@
+import responsiveToPx from "@/src/utils/responsiveToPx";
+import styled from "styled-components/native";
+
+export const AiChatLayout = styled.View`
+  flex-direction: row;
+  align-items: center;
+  margin-top: ${responsiveToPx("20px")};
+  margin-left: ${responsiveToPx("15px")};
+  gap: ${({ theme }) => theme.gap.md};
+`;
+
+export const Image = styled.Image`
+  width: ${responsiveToPx("36px")};
+  height: ${responsiveToPx("36px")};
+  border-radius: 9999px;
+`;
+
+export const AiChatBox = styled.View`
+  max-width: ${responsiveToPx("290px")};
+  border-radius: ${({ theme }) => theme.borderRadius.base};
+  background-color: ${({ theme }) => theme.colors.white};
+  padding: ${responsiveToPx("20px")} ${responsiveToPx("15px")};
+  align-self: flex-start;
+`;
+
+export const AiChatText = styled.Text`
+  color: ${({ theme }) => theme.colors.assistantChat};
+  font-family: ${({ theme }) => theme.fontFamily.nsRegular};
+  font-size: ${({ theme }) => theme.fontSize.md};
+  line-height: ${responsiveToPx("24px")};
+`;

--- a/src/pages/Chatting/AiChatBox/styles.ts
+++ b/src/pages/Chatting/AiChatBox/styles.ts
@@ -19,7 +19,7 @@ export const AiChatBox = styled.View`
   max-width: ${responsiveToPx("290px")};
   border-radius: ${({ theme }) => theme.borderRadius.base};
   background-color: ${({ theme }) => theme.colors.white};
-  padding: ${responsiveToPx("20px")} ${responsiveToPx("15px")};
+  padding: ${responsiveToPx("12px")} ${responsiveToPx("15px")};
   align-self: flex-start;
 `;
 

--- a/src/pages/Chatting/UserChatBox/index.tsx
+++ b/src/pages/Chatting/UserChatBox/index.tsx
@@ -1,0 +1,16 @@
+import { shadowProps } from "@/src/constants/shadowProps";
+import * as S from "./styles";
+
+interface Props {
+  input: string;
+}
+
+function UserChatBox({ input }: Props): JSX.Element {
+  return (
+    <S.UserChatLayout style={shadowProps}>
+      <S.UserChatText>{input}</S.UserChatText>
+    </S.UserChatLayout>
+  );
+}
+
+export default UserChatBox;

--- a/src/pages/Chatting/UserChatBox/styles.ts
+++ b/src/pages/Chatting/UserChatBox/styles.ts
@@ -1,0 +1,19 @@
+import responsiveToPx from "@/src/utils/responsiveToPx";
+import styled from "styled-components/native";
+
+export const UserChatLayout = styled.View`
+  max-width: ${responsiveToPx("290px")};
+  border-radius: ${({ theme }) => theme.borderRadius.base};
+  margin-top: ${responsiveToPx("20px")};
+  margin-right: ${responsiveToPx("15px")};
+  background-color: ${({ theme }) => theme.colors.deepGreen};
+  padding: ${responsiveToPx("20px")} ${responsiveToPx("15px")};
+  align-self: flex-end;
+`;
+
+export const UserChatText = styled.Text`
+  color: ${({ theme }) => theme.colors.userChat};
+  font-family: ${({ theme }) => theme.fontFamily.nsRegular};
+  font-size: ${({ theme }) => theme.fontSize.md};
+  line-height: ${responsiveToPx("24px")};
+`;

--- a/src/pages/Chatting/UserChatBox/styles.ts
+++ b/src/pages/Chatting/UserChatBox/styles.ts
@@ -4,10 +4,9 @@ import styled from "styled-components/native";
 export const UserChatLayout = styled.View`
   max-width: ${responsiveToPx("290px")};
   border-radius: ${({ theme }) => theme.borderRadius.base};
-  margin-top: ${responsiveToPx("20px")};
-  margin-right: ${responsiveToPx("15px")};
+  margin: ${responsiveToPx("12px")} ${responsiveToPx("10px")};
   background-color: ${({ theme }) => theme.colors.deepGreen};
-  padding: ${responsiveToPx("20px")} ${responsiveToPx("15px")};
+  padding: ${responsiveToPx("12px")} ${responsiveToPx("15px")};
   align-self: flex-end;
 `;
 

--- a/src/pages/Chatting/index.tsx
+++ b/src/pages/Chatting/index.tsx
@@ -42,11 +42,15 @@ function ChattingPage({ threadDate, expiredDate }: Props): JSX.Element {
   }
 
   return (
-    <S.SafeView>
+    <S.SafeView edges={["left", "right", "top"]}>
       <S.HeaderBox>
-        <S.BackButton onPress={handleBackPress} hitSlop={10}>
+        <S.BackButton onPress={handleBackPress} hitSlop={7}>
           <MaterialIcons name="arrow-back-ios" size={28} color={theme.colors.black} />
         </S.BackButton>
+        <S.HeaderButton hitSlop={7}>
+          <S.Image source={{ uri: data.result.aiProfileImageS3 }} />
+          <S.AiNameText>{data.result.aiProfileName}</S.AiNameText>
+        </S.HeaderButton>
       </S.HeaderBox>
       <S.ScrollBox>
         {data.result.chats.map((chat) =>

--- a/src/pages/Chatting/index.tsx
+++ b/src/pages/Chatting/index.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useRef, useState } from "react";
-import { ScrollView } from "react-native";
+import { Platform, ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -15,6 +15,7 @@ import { ThreadDate } from "@/src/types/threadTypes";
 import * as S from "./styles";
 import toastMessage from "@/src/constants/toastMessage";
 import showToast from "@/src/libs/showToast";
+import { shadowProps } from "@/src/constants/shadowProps";
 
 interface Props {
   threadDate: ThreadDate;
@@ -108,7 +109,16 @@ function ChattingPage({ threadDate, expiredDate }: Props): JSX.Element {
             )
           )}
         </S.ScrollBox>
-        <S.TextInputBox></S.TextInputBox>
+        <S.ChatInputBox behavior={Platform.OS === "ios" ? "padding" : "height"}>
+          <S.ChatInput
+            placeholder="오늘 하루에 대해 말해주세요"
+            hitSlop={15}
+            placeholderTextColor={theme.colors.placeholderText}
+          />
+          <S.ChatButton hitSlop={15} style={shadowProps}>
+            <S.ButtonImage source={require("@/assets/images/chatButton.png")} />
+          </S.ChatButton>
+        </S.ChatInputBox>
       </S.SafeView>
     </Fragment>
   );

--- a/src/pages/Chatting/index.tsx
+++ b/src/pages/Chatting/index.tsx
@@ -1,0 +1,22 @@
+import { useRouter } from "expo-router";
+import { Text, TouchableOpacity } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+function ChattingPage(): JSX.Element {
+  const router = useRouter();
+
+  const handleBackPress = () => {
+    router.back();
+  };
+
+  return (
+    <SafeAreaView>
+      <Text>채팅 페이지 입니다</Text>
+      <TouchableOpacity onPress={handleBackPress}>
+        <Text>뒤로가기</Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  );
+}
+
+export default ChattingPage;

--- a/src/pages/Chatting/index.tsx
+++ b/src/pages/Chatting/index.tsx
@@ -1,11 +1,13 @@
 import { useRouter } from "expo-router";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import { Text, TouchableOpacity } from "react-native";
 import { useQuery } from "@tanstack/react-query";
 import { getMessagesFn } from "@/src/apis/threadApi";
 import Loading from "@/src/components/ui/Loading";
 import CommonError from "@/src/components/ui/CommonError";
+import UserChatBox from "./UserChatBox";
+import AiChatBox from "./AiChatBox";
 import { ThreadDate } from "@/src/types/threadTypes";
+import { theme } from "@/src/constants/theme";
 import * as S from "./styles";
 
 interface Props {
@@ -43,16 +45,23 @@ function ChattingPage({ threadDate, expiredDate }: Props): JSX.Element {
     <S.SafeView>
       <S.HeaderBox>
         <S.BackButton onPress={handleBackPress} hitSlop={10}>
-          <MaterialIcons name="arrow-back-ios" size={28} color="black" />
+          <MaterialIcons name="arrow-back-ios" size={28} color={theme.colors.black} />
         </S.BackButton>
       </S.HeaderBox>
-      <Text>
-        {threadDate.day}
-        {expiredDate.toString()}
-      </Text>
-      <TouchableOpacity onPress={handleBackPress}>
-        <Text>뒤로가기</Text>
-      </TouchableOpacity>
+      <S.ScrollBox>
+        {data.result.chats.map((chat) =>
+          chat.role === "AI" ? (
+            <AiChatBox
+              content={chat.content}
+              imageUrl={chat.aiProfileImageS3}
+              key={chat.createAt}
+            />
+          ) : (
+            <UserChatBox input={chat.content} key={chat.createAt} />
+          )
+        )}
+      </S.ScrollBox>
+      <S.TextInputBox></S.TextInputBox>
     </S.SafeView>
   );
 }

--- a/src/pages/Chatting/index.tsx
+++ b/src/pages/Chatting/index.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "expo-router";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { Text, TouchableOpacity } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import * as S from "./styles";
 
 function ChattingPage(): JSX.Element {
   const router = useRouter();
@@ -10,12 +11,17 @@ function ChattingPage(): JSX.Element {
   };
 
   return (
-    <SafeAreaView>
+    <S.SafeView>
+      <S.HeaderBox>
+        <S.BackButton onPress={handleBackPress} hitSlop={10}>
+          <MaterialIcons name="arrow-back-ios" size={28} color="black" />
+        </S.BackButton>
+      </S.HeaderBox>
       <Text>채팅 페이지 입니다</Text>
       <TouchableOpacity onPress={handleBackPress}>
         <Text>뒤로가기</Text>
       </TouchableOpacity>
-    </SafeAreaView>
+    </S.SafeView>
   );
 }
 

--- a/src/pages/Chatting/index.tsx
+++ b/src/pages/Chatting/index.tsx
@@ -2,8 +2,14 @@ import { useRouter } from "expo-router";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { Text, TouchableOpacity } from "react-native";
 import * as S from "./styles";
+import { ThreadDate } from "@/src/types/threadTypes";
 
-function ChattingPage(): JSX.Element {
+interface Props {
+  threadDate: ThreadDate;
+  expiredDate: Date;
+}
+
+function ChattingPage({ threadDate, expiredDate }: Props): JSX.Element {
   const router = useRouter();
 
   const handleBackPress = () => {
@@ -17,7 +23,10 @@ function ChattingPage(): JSX.Element {
           <MaterialIcons name="arrow-back-ios" size={28} color="black" />
         </S.BackButton>
       </S.HeaderBox>
-      <Text>채팅 페이지 입니다</Text>
+      <Text>
+        {threadDate.day}
+        {expiredDate.toString()}
+      </Text>
       <TouchableOpacity onPress={handleBackPress}>
         <Text>뒤로가기</Text>
       </TouchableOpacity>

--- a/src/pages/Chatting/index.tsx
+++ b/src/pages/Chatting/index.tsx
@@ -1,8 +1,12 @@
 import { useRouter } from "expo-router";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { Text, TouchableOpacity } from "react-native";
-import * as S from "./styles";
+import { useQuery } from "@tanstack/react-query";
+import { getMessagesFn } from "@/src/apis/threadApi";
+import Loading from "@/src/components/ui/Loading";
+import CommonError from "@/src/components/ui/CommonError";
 import { ThreadDate } from "@/src/types/threadTypes";
+import * as S from "./styles";
 
 interface Props {
   threadDate: ThreadDate;
@@ -12,9 +16,28 @@ interface Props {
 function ChattingPage({ threadDate, expiredDate }: Props): JSX.Element {
   const router = useRouter();
 
+  const { isPending, isError, data, refetch } = useQuery({
+    queryFn: () => getMessagesFn(threadDate),
+    queryKey: ["message", threadDate],
+  });
+
   const handleBackPress = () => {
     router.back();
   };
+
+  if (isPending) {
+    return <Loading />;
+  }
+
+  if (isError) {
+    return (
+      <CommonError
+        titleText="채팅 내역을 불러오지 못했어요"
+        buttonText="다시 불러오기"
+        onPress={refetch}
+      />
+    );
+  }
 
   return (
     <S.SafeView>

--- a/src/pages/Chatting/index.tsx
+++ b/src/pages/Chatting/index.tsx
@@ -1,4 +1,5 @@
-import { Fragment, useState } from "react";
+import { Fragment, useRef, useState } from "react";
+import { ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -19,6 +20,7 @@ interface Props {
 }
 
 function ChattingPage({ threadDate, expiredDate }: Props): JSX.Element {
+  const scrollViewRef = useRef<ScrollView>(null);
   const [isVisible, setIsVisible] = useState<boolean>(false);
   const queryClient = useQueryClient();
   const router = useRouter();
@@ -82,7 +84,12 @@ function ChattingPage({ threadDate, expiredDate }: Props): JSX.Element {
             <S.AiNameText>{data.result.aiProfileName}</S.AiNameText>
           </S.HeaderButton>
         </S.HeaderBox>
-        <S.ScrollBox>
+        <S.ScrollBox
+          ref={scrollViewRef}
+          onContentSizeChange={() => {
+            scrollViewRef.current?.scrollToEnd();
+          }}
+        >
           {data.result.chats.map((chat) =>
             chat.role === "AI" ? (
               <AiChatBox

--- a/src/pages/Chatting/index.tsx
+++ b/src/pages/Chatting/index.tsx
@@ -13,6 +13,8 @@ import { theme } from "@/src/constants/theme";
 import { setAiProfileId } from "@/src/libs/mmkv";
 import { ThreadDate } from "@/src/types/threadTypes";
 import * as S from "./styles";
+import toastMessage from "@/src/constants/toastMessage";
+import showToast from "@/src/libs/showToast";
 
 interface Props {
   threadDate: ThreadDate;
@@ -35,9 +37,13 @@ function ChattingPage({ threadDate, expiredDate }: Props): JSX.Element {
     onSuccess: (data) => {
       console.log(data);
       queryClient.invalidateQueries({ queryKey: ["message", threadDate] });
+      showToast(toastMessage.changeAssistant.success, "success");
       setIsVisible(false);
     },
-    onError: (error) => console.error(error.response?.data),
+    onError: (error) => {
+      console.error(error.response?.data);
+      showToast(toastMessage.changeAssistant.failed, "error");
+    },
   });
 
   const handleHeaderPress = () => {

--- a/src/pages/Chatting/styles.ts
+++ b/src/pages/Chatting/styles.ts
@@ -1,5 +1,6 @@
 import { ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { Image as Img } from "expo-image";
 import styled from "styled-components/native";
 import responsiveToPx from "@/src/utils/responsiveToPx";
 
@@ -19,6 +20,13 @@ export const HeaderBox = styled.View`
   padding: 0px ${responsiveToPx("24px")};
   align-items: center;
   gap: ${({ theme }) => theme.gap.lg};
+`;
+
+export const BackButton = styled.TouchableOpacity`
+  width: ${responsiveToPx("28px")};
+  height: ${responsiveToPx("28px")};
+  justify-content: center;
+  align-items: center;
 `;
 
 export const HeaderButton = styled.TouchableOpacity`
@@ -44,14 +52,36 @@ export const ScrollBox = styled(ScrollView)`
   background-color: ${({ theme }) => theme.colors.whiteBlue};
 `;
 
-export const TextInputBox = styled.View`
+export const ChatInputBox = styled.KeyboardAvoidingView`
   flex: 0.13;
+  flex-direction: row;
   background-color: ${({ theme }) => theme.colors.whiteBlue};
-`;
-
-export const BackButton = styled.TouchableOpacity`
-  width: ${responsiveToPx("28px")};
-  height: ${responsiveToPx("28px")};
   justify-content: center;
   align-items: center;
+  padding-bottom: ${responsiveToPx("20px")};
+  gap: ${({ theme }) => theme.gap.md};
+`;
+
+export const ChatInput = styled.TextInput`
+  min-width: ${responsiveToPx("333px")};
+  padding: ${responsiveToPx("11px")} ${responsiveToPx("16px")};
+  background-color: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${({ theme }) => theme.colors.gray};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  font-family: ${({ theme }) => theme.fontFamily.nsRegular};
+  font-size: ${({ theme }) => theme.fontSize.base};
+`;
+
+export const ChatButton = styled.TouchableOpacity`
+  width: ${responsiveToPx("44px")};
+  height: ${responsiveToPx("44px")};
+  border-radius: 9999px;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+`;
+
+export const ButtonImage = styled(Img)`
+  width: 120%;
+  height: 120%;
 `;

--- a/src/pages/Chatting/styles.ts
+++ b/src/pages/Chatting/styles.ts
@@ -1,6 +1,7 @@
-import responsiveToPx from "@/src/utils/responsiveToPx";
+import { ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
+import responsiveToPx from "@/src/utils/responsiveToPx";
 
 export const SafeView = styled(SafeAreaView)`
   flex: 1;
@@ -38,7 +39,7 @@ export const AiNameText = styled.Text`
   font-size: ${({ theme }) => theme.fontSize.lg};
 `;
 
-export const ScrollBox = styled.ScrollView`
+export const ScrollBox = styled(ScrollView)`
   flex: 0.75;
   background-color: ${({ theme }) => theme.colors.whiteBlue};
 `;

--- a/src/pages/Chatting/styles.ts
+++ b/src/pages/Chatting/styles.ts
@@ -1,0 +1,20 @@
+import responsiveToPx from "@/src/utils/responsiveToPx";
+import { SafeAreaView } from "react-native-safe-area-context";
+import styled from "styled-components/native";
+
+export const SafeView = styled(SafeAreaView)`
+  flex: 1;
+`;
+
+export const HeaderBox = styled.View`
+  width: 100%;
+  height: ${responsiveToPx("80px")};
+  justify-content: center;
+`;
+
+export const BackButton = styled.TouchableOpacity`
+  width: ${responsiveToPx("28px")};
+  height: ${responsiveToPx("28px")};
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/pages/Chatting/styles.ts
+++ b/src/pages/Chatting/styles.ts
@@ -6,6 +6,10 @@ export const SafeView = styled(SafeAreaView)`
   flex: 1;
 `;
 
+export const FlexView = styled.View`
+  flex: 1;
+`;
+
 export const HeaderBox = styled.View`
   width: 100%;
   height: ${responsiveToPx("80px")};

--- a/src/pages/Chatting/styles.ts
+++ b/src/pages/Chatting/styles.ts
@@ -4,6 +4,7 @@ import styled from "styled-components/native";
 
 export const SafeView = styled(SafeAreaView)`
   flex: 1;
+  background-color: ${({ theme }) => theme.colors.white};
 `;
 
 export const FlexView = styled.View`
@@ -12,17 +13,39 @@ export const FlexView = styled.View`
 
 export const HeaderBox = styled.View`
   flex: 0.12;
-  justify-content: center;
-  background-color: rebeccapurple;
+  background-color: ${({ theme }) => theme.colors.white};
+  flex-direction: row;
+  padding: 0px ${responsiveToPx("24px")};
+  align-items: center;
+  gap: ${({ theme }) => theme.gap.lg};
 `;
+
+export const HeaderButton = styled.TouchableOpacity`
+  flex-direction: row;
+  gap: ${({ theme }) => theme.gap.lg};
+  align-items: center;
+`;
+
+export const Image = styled.Image`
+  width: ${responsiveToPx("48px")};
+  height: ${responsiveToPx("48px")};
+  border-radius: 9999px;
+`;
+
+export const AiNameText = styled.Text`
+  color: ${({ theme }) => theme.colors.black};
+  font-family: ${({ theme }) => theme.fontFamily.nsBold};
+  font-size: ${({ theme }) => theme.fontSize.lg};
+`;
+
 export const ScrollBox = styled.ScrollView`
-  flex: 0.73;
-  background-color: beige;
+  flex: 0.75;
+  background-color: ${({ theme }) => theme.colors.whiteBlue};
 `;
 
 export const TextInputBox = styled.View`
-  flex: 0.15;
-  background-color: crimson;
+  flex: 0.13;
+  background-color: ${({ theme }) => theme.colors.whiteBlue};
 `;
 
 export const BackButton = styled.TouchableOpacity`

--- a/src/pages/Chatting/styles.ts
+++ b/src/pages/Chatting/styles.ts
@@ -11,9 +11,18 @@ export const FlexView = styled.View`
 `;
 
 export const HeaderBox = styled.View`
-  width: 100%;
-  height: ${responsiveToPx("80px")};
+  flex: 0.12;
   justify-content: center;
+  background-color: rebeccapurple;
+`;
+export const ScrollBox = styled.ScrollView`
+  flex: 0.73;
+  background-color: beige;
+`;
+
+export const TextInputBox = styled.View`
+  flex: 0.15;
+  background-color: crimson;
 `;
 
 export const BackButton = styled.TouchableOpacity`

--- a/src/pages/MakeAssistant/Submit/index.tsx
+++ b/src/pages/MakeAssistant/Submit/index.tsx
@@ -38,12 +38,17 @@ function Submit({ answers }: Props) {
     if (isNewUser) {
       console.log("새로운 유저입니다. mmkv에 생성된 어시스턴트 id를 저장합니다...");
       setStorageValue("aiProfileId", data.result.aiProfileId.toString());
+      setTimeout(() => {
+        console.log("/main으로 리다이렉트합니다.");
+        router.replace("/(app)/main");
+      }, 2500);
     } else {
       console.log("기존 유저입니다. mmkv를 그대로 둡니다...");
+      setTimeout(() => {
+        console.log("이전 페이지로 back 합니다.");
+        router.back();
+      }, 2500);
     }
-    setTimeout(() => {
-      router.replace("/(app)/main");
-    }, 2500);
   };
 
   // 초기 mutation 실행

--- a/src/pages/MakeAssistant/Submit/index.tsx
+++ b/src/pages/MakeAssistant/Submit/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "expo-router";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useIsNewUserContext } from "@/src/contexts/IsNewUserProvider";
 import { makeAssistantFn } from "@/src/apis/aiProfileApi";
 import Button from "@/src/components/ui/Button";
@@ -14,6 +14,7 @@ interface Props {
 }
 
 function Submit({ answers }: Props) {
+  const queryClient = useQueryClient();
   const isNewUser = useIsNewUserContext();
   const { isPending, isSuccess, isError, error, mutate } = useMutation({
     mutationFn: () => makeAssistantFn(answersJson),
@@ -44,6 +45,7 @@ function Submit({ answers }: Props) {
       }, 2500);
     } else {
       console.log("기존 유저입니다. mmkv를 그대로 둡니다...");
+      queryClient.invalidateQueries({ queryKey: ["assistant-list"] });
       setTimeout(() => {
         console.log("이전 페이지로 back 합니다.");
         router.back();

--- a/src/pages/MakeAssistant/Submit/index.tsx
+++ b/src/pages/MakeAssistant/Submit/index.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "expo-router";
 import { useMutation } from "@tanstack/react-query";
+import { useIsNewUserContext } from "@/src/contexts/IsNewUserProvider";
 import { makeAssistantFn } from "@/src/apis/aiProfileApi";
 import Button from "@/src/components/ui/Button";
 import { fadeIn, fadeOut } from "@/src/libs/animations";
+import { setStorageValue } from "@/src/libs/mmkv";
 import { AiProfileMakeAnswers, AiProfileMakeResult } from "@/src/types/aiProfileTypes";
 import * as S from "./styles";
 
@@ -12,6 +14,7 @@ interface Props {
 }
 
 function Submit({ answers }: Props) {
+  const isNewUser = useIsNewUserContext();
   const { isPending, isSuccess, isError, error, mutate } = useMutation({
     mutationFn: () => makeAssistantFn(answersJson),
     onSuccess: (data) => handleSuccess(data),
@@ -32,6 +35,12 @@ function Submit({ answers }: Props) {
   // mutation 성공 핸들러
   const handleSuccess = (data: AiProfileMakeResult) => {
     console.log(data.message);
+    if (isNewUser) {
+      console.log("새로운 유저입니다. mmkv에 생성된 어시스턴트 id를 저장합니다...");
+      setStorageValue("aiProfileId", data.result.aiProfileId.toString());
+    } else {
+      console.log("기존 유저입니다. mmkv를 그대로 둡니다...");
+    }
     setTimeout(() => {
       router.replace("/(app)/main");
     }, 2500);

--- a/src/test/time.test.ts
+++ b/src/test/time.test.ts
@@ -1,4 +1,4 @@
-import { threadDateExpired } from "@/src/utils/time";
+import { checkThreadExpire, threadDateExpired } from "@/src/utils/time";
 
 describe("threadDateExpired", () => {
   beforeEach(() => {
@@ -42,5 +42,29 @@ describe("threadDateExpired", () => {
 
     const result = threadDateExpired(3);
     expect(result).toEqual([{ year: 2025, month: 12, day: 31 }, new Date(2026, 0, 1, 3)]);
+  });
+});
+
+describe("checkThreadExpire", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("현재 만료일 이전이라면 false 반환", () => {
+    jest.setSystemTime(new Date(2025, 1, 5, 10, 0));
+    const expiredDate = new Date(2025, 1, 5, 15, 0);
+
+    expect(checkThreadExpire(expiredDate)).toBe(false);
+  });
+
+  test("현재 만료일을 지났다면 true 반환", () => {
+    jest.setSystemTime(new Date(2025, 1, 5, 16, 0));
+    const expiredDate = new Date(2025, 1, 5, 15, 0);
+
+    expect(checkThreadExpire(expiredDate)).toBe(true);
   });
 });

--- a/src/test/time.test.ts
+++ b/src/test/time.test.ts
@@ -1,6 +1,6 @@
-import { checkThreadExpire, threadDateExpired } from "@/src/utils/time";
+import { checkThreadExpire, getThreadDateExpired } from "@/src/utils/time";
 
-describe("threadDateExpired", () => {
+describe("getThreadDateExpired", () => {
   beforeEach(() => {
     jest.useFakeTimers();
   });
@@ -12,35 +12,35 @@ describe("threadDateExpired", () => {
   test("현재 시간이 3시 30분이고 sleepHour가 3시일 때", () => {
     jest.setSystemTime(new Date(2025, 1, 5, 3, 30));
 
-    const result = threadDateExpired(3);
+    const result = getThreadDateExpired(3);
     expect(result).toEqual([{ year: 2025, month: 2, day: 5 }, new Date(2025, 1, 6, 3)]);
   });
 
   test("현재 시간이 2시이고 sleepHour가 3시일 때", () => {
     jest.setSystemTime(new Date(2025, 1, 5, 2, 0));
 
-    const result = threadDateExpired(3);
+    const result = getThreadDateExpired(3);
     expect(result).toEqual([{ year: 2025, month: 2, day: 4 }, new Date(2025, 1, 5, 3)]);
   });
 
   test("현재 시간이 13시이고 sleepHour가 3시일 때", () => {
     jest.setSystemTime(new Date(2025, 1, 5, 13, 0));
 
-    const result = threadDateExpired(3);
+    const result = getThreadDateExpired(3);
     expect(result).toEqual([{ year: 2025, month: 2, day: 5 }, new Date(2025, 1, 6, 3)]);
   });
 
   test("현재가 2월 28일 23시이고 sleepHour가 2시일 때", () => {
     jest.setSystemTime(new Date(2025, 1, 28, 23, 0));
 
-    const result = threadDateExpired(2);
+    const result = getThreadDateExpired(2);
     expect(result).toEqual([{ year: 2025, month: 2, day: 28 }, new Date(2025, 2, 1, 2)]);
   });
 
   test("현재가 12월 31일 23시이고 sleepHour가 3시일 때", () => {
     jest.setSystemTime(new Date(2025, 11, 31, 23, 0));
 
-    const result = threadDateExpired(3);
+    const result = getThreadDateExpired(3);
     expect(result).toEqual([{ year: 2025, month: 12, day: 31 }, new Date(2026, 0, 1, 3)]);
   });
 });

--- a/src/test/time.test.ts
+++ b/src/test/time.test.ts
@@ -1,0 +1,46 @@
+import { threadDateExpired } from "@/src/utils/time";
+
+describe("threadDateExpired", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("현재 시간이 3시 30분이고 sleepHour가 3시일 때", () => {
+    jest.setSystemTime(new Date(2025, 1, 5, 3, 30));
+
+    const result = threadDateExpired(3);
+    expect(result).toEqual([{ year: 2025, month: 2, day: 5 }, new Date(2025, 1, 6, 3)]);
+  });
+
+  test("현재 시간이 2시이고 sleepHour가 3시일 때", () => {
+    jest.setSystemTime(new Date(2025, 1, 5, 2, 0));
+
+    const result = threadDateExpired(3);
+    expect(result).toEqual([{ year: 2025, month: 2, day: 4 }, new Date(2025, 1, 5, 3)]);
+  });
+
+  test("현재 시간이 13시이고 sleepHour가 3시일 때", () => {
+    jest.setSystemTime(new Date(2025, 1, 5, 13, 0));
+
+    const result = threadDateExpired(3);
+    expect(result).toEqual([{ year: 2025, month: 2, day: 5 }, new Date(2025, 1, 6, 3)]);
+  });
+
+  test("현재가 2월 28일 23시이고 sleepHour가 2시일 때", () => {
+    jest.setSystemTime(new Date(2025, 1, 28, 23, 0));
+
+    const result = threadDateExpired(2);
+    expect(result).toEqual([{ year: 2025, month: 2, day: 28 }, new Date(2025, 2, 1, 2)]);
+  });
+
+  test("현재가 12월 31일 23시이고 sleepHour가 3시일 때", () => {
+    jest.setSystemTime(new Date(2025, 11, 31, 23, 0));
+
+    const result = threadDateExpired(3);
+    expect(result).toEqual([{ year: 2025, month: 12, day: 31 }, new Date(2026, 0, 1, 3)]);
+  });
+});

--- a/src/types/threadTypes.ts
+++ b/src/types/threadTypes.ts
@@ -1,0 +1,18 @@
+import { SuccessResponse } from "@/src/types/commonTypes";
+
+export type NewThreadResult = SuccessResponse & {
+  result: {
+    threadId: number;
+    year: number;
+    month: number;
+    day: number;
+  };
+};
+
+export type ThreadDate = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+export type ExpiredDate = Date;

--- a/src/types/threadTypes.ts
+++ b/src/types/threadTypes.ts
@@ -17,6 +17,7 @@ export type ThreadDate = {
 
 export type Chat = {
   role: "AI" | "USER";
+  chatId: number;
   content: string;
   createAt: string;
   aiProfileName: string;
@@ -32,3 +33,5 @@ export type MessageResult = SuccessResponse & {
 };
 
 export type ExpiredDate = Date;
+
+export type FluxEvent = "aiMessage" | "finish";

--- a/src/types/threadTypes.ts
+++ b/src/types/threadTypes.ts
@@ -15,4 +15,20 @@ export type ThreadDate = {
   day: number;
 };
 
+export type Chat = {
+  role: "AI" | "USER";
+  content: string;
+  createAt: string;
+  aiProfileName: string;
+  aiProfileImageS3: string;
+};
+
+export type MessageResult = SuccessResponse & {
+  result: {
+    aiProfileName: string;
+    aiProfileImageS3: string;
+    chats: Chat[];
+  };
+};
+
 export type ExpiredDate = Date;

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,10 +1,4 @@
-type ThreadDate = {
-  year: number;
-  month: number;
-  day: number;
-};
-
-type ExpiredDate = Date;
+import { ExpiredDate, ThreadDate } from "@/src/types/threadTypes";
 
 export const getThreadDateExpired = (sleepHour: number): [ThreadDate, ExpiredDate] => {
   const date = new Date();

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,36 @@
+type ThreadDate = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+type ExpiredDate = Date;
+
+export const threadDateExpired = (sleepHour: number): [ThreadDate, ExpiredDate] => {
+  const date = new Date();
+  const curHour = date.getHours();
+
+  const createdDate = new Date();
+  const expiredDate = new Date();
+
+  if (sleepHour <= curHour) {
+    // 자는 시간 <= 생성 시간 : 스레드 생성은 당일, 만료일은 다음날 자는 시간
+    expiredDate.setDate(expiredDate.getDate() + 1);
+  } else {
+    // 자는 시간 > 생성 시간: 스레드 생성은 전날, 만료일은 오늘 자는 시간
+    createdDate.setDate(createdDate.getDate() - 1);
+  }
+
+  expiredDate.setHours(sleepHour, 0, 0, 0); // 분 초는 0으로
+
+  return [
+    {
+      year: createdDate.getFullYear(),
+      month: createdDate.getMonth() + 1,
+      day: createdDate.getDate(),
+    },
+    expiredDate,
+  ];
+};
+
+// 만료일 이후면 당일 스레드 재생성

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -6,7 +6,7 @@ type ThreadDate = {
 
 type ExpiredDate = Date;
 
-export const threadDateExpired = (sleepHour: number): [ThreadDate, ExpiredDate] => {
+export const getThreadDateExpired = (sleepHour: number): [ThreadDate, ExpiredDate] => {
   const date = new Date();
   const curHour = date.getHours();
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -21,7 +21,7 @@ export const threadDateExpired = (sleepHour: number): [ThreadDate, ExpiredDate] 
     createdDate.setDate(createdDate.getDate() - 1);
   }
 
-  expiredDate.setHours(sleepHour, 0, 0, 0); // 분 초는 0으로
+  expiredDate.setHours(sleepHour, 0, 0, 0); // 분 초 ms는 0으로
 
   return [
     {
@@ -33,4 +33,8 @@ export const threadDateExpired = (sleepHour: number): [ThreadDate, ExpiredDate] 
   ];
 };
 
-// 만료일 이후면 당일 스레드 재생성
+// 만료일 이후인지 확인
+export const checkThreadExpire = (expiredDate: ExpiredDate) => {
+  const now = new Date();
+  return now > expiredDate;
+};


### PR DESCRIPTION
# 개요

- 자는 시간과 스레드 생성 간 관계를 활용해 로직을 설계하고, 테스트 코드로 검증
- `react-native-sse`를 활용해 낙관적 업데이트와 유사한 UX 구현 후, 완료되면 `invalidate`시켜 예기치 못 한 오차가 발생해도 수정되도록 구현

> 먼저 `Tanstack-query`의 강력함, 편리함을 느꼈다. 여러 API (설정값 가져오기, 스레드 생성, 메시지 가져오기)를 직렬적으로 호출해야 했는데, Axios만 썼으면 에러 핸들링과 동시에 실행 흐름을 유지하기 매우 어려웠을 것 같다.
다음으로, 테스트 코드에 흥미를 가지게 되었다. 사용자의 자는 시간과 현재 시간의 다양한 경우에 따라 스레드 생성에 필요한 년/월/일 값이 달라지는데, 엣지 케이스를 중점으로 확실히 확인해볼 수 있어 마음이 편해졌다. 왜 쓰는지 알 것 같았고, `Jest`를 제대로 공부해서 React 프로젝트에서 사용해보고 싶다.

---

## 구현

- [X] 캘린더에서 채팅 버튼 누르면, 채팅 페이지로 push되도록 구현
- [X] 초기 유저가 생성한 `aiProfileId`는 mmkv에 저장하도록 `MakeAssistantPage`의 `Submit` 컴포넌트 수정 → 새 계정으로 테스트 완료
- [X] `MakeAssistantPage`에서 어시스턴트 생성이 끝나면, 초기 유저는 `/main`으로 리다이렉트, 기존 유저는 `router.back()`으로 이전 페이지로 돌아가도록 구현 (초기 유저를 기존 유저로 변경하는 트리거는 `/main`에 존재하므로 안전)
- [X] `refresh token`, `access token`, `aiProfileId`를 반환하는 헬퍼 함수들을 구현하고, 리팩토링
- [X] 자는 시간과 현재 시간을 활용해 어떤 날짜의 스레드를 요청/생성해야 하는지와 스레드 만료시간을 반환하는 로직 구현 후, GPT 도움을 받아 엣지 케이스에 대한 테스트 코드 작성 (테스트코드 엄청나다. 마음이 편해진다)
- [X] `ChatRouter`에서 `useUserSetting` 커스텀 훅을 사용해 사용자의 자는 시간을 가져오도록 구현
- [X] `ChatRouter`에서 스레드를 생성하는 `mutationFn`, `useMutate`를 구현하고, 자는 시간을 가져오는 데 성공하면, 위의 로직을 활용해 스레드를 생성하는 `mutate`를 `useEffect`를 활용해 실행. 이 과정에서 스레드 생성 년/월/일과 스레드 제거 시점을 state에 저장. 각 단계에서 실패 시 버튼으로 재시도가 가능하도록 에러 핸들링. 모든 준비가 끝나면 `ChatPage`를 렌더링하도록 구현
- [X] 로그아웃 시 `aiProfileId`를 mmkv에서 제거 (깜빡했는데, 다른 계정으로 로그인해서 채팅 페이지 들어가니까 권한이 없는 `aiProfileId`라는 에러 코드를 받았다.)
- [X] 어시스턴트 모달창에서 어시스턴트를 선택할 때 실행될 함수를 props로 받도록 구현
- [X] mmkv에 `aiProfileId`가 없으면, `AssistantList` 컴포넌트에서 AI를 선택해 mmkv에 저장하고, 다시 `mutate`할 수 있도록 에러 핸들링 추가
- [X] 스레드 내 메시지를 가져오는 `queryFn`을 구현한 뒤, 스레드를 생성하는 `useMutate`의 `onSuccess` 함수에서 년/월/일를 통해 스레드 내 메시지를 `prefetch` 하도록 구현
- [X] 채팅 페이지 헤더 구현
- [X] 채팅 페이지 헤더에서 아이콘을 클릭하면, `AssistantList` 렌더링되도록 구현
- [X] `aiProfileId`를 변경하는 `mutationFn`과 `useMutation`을 구현하고, 채팅 페이지 헤더에서 아이콘을 클릭한 뒤 새 AI를 선택하면, mmkv에 저장하고 `mutate`를 실행하고, 성공하면 `AssistantList`를 닫고 채팅 쿼리를 `invalidate`하도록 구현
- [X] `aiProfileId` 변경에 성공/실패 시 각각 `Toast message` 출력 구현
- [X] `ChatPage`에 채팅 영역(`ScrollView`)과 하단 `TextInput`, 제출 버튼 구현. 키보드에 가려지지 않게 [KeyboardAvoidingView](https://reactnative.dev/docs/keyboardavoidingview) 사용
- [X] `react-native-sse`를 사용해 사용자 채팅을 전송하고, 응답을 받아 `queryClient.setQueryData()`를 활용해서 `aiMessage` 이벤트를 수신해 쿼리 업데이트하다가, SSE가 끝나면 `invalidateQuery` 처리해 데이터 정합성 보장하도록 구현
- [X] 레이아웃 Figma 기반으로 디자인 마무리

---

## 구현 결과

https://github.com/user-attachments/assets/07a66d0f-082f-44b5-8b99-34e617b81208

---
