### PR TITLE
캘린더 페이지 태그 줄바꿈되는 문제 수정

### DIFF
--- a/src/pages/Calendar/DayComponent/index.tsx
+++ b/src/pages/Calendar/DayComponent/index.tsx
@@ -30,10 +30,14 @@ function DayComponent({ date, calendars, onPress }: Props): JSX.Element {
         <S.Image src={dayDiary.imageS3} />
       </S.ImageBox>
       <S.TagBox>
-        <S.TagText>{dayDiary.hashTag1}</S.TagText>
+        <S.TagText numberOfLines={1} ellipsizeMode="clip">
+          {dayDiary.hashTag1}
+        </S.TagText>
       </S.TagBox>
       <S.TagBox>
-        <S.TagText>{dayDiary.hashTag2}</S.TagText>
+        <S.TagText numberOfLines={1} ellipsizeMode="clip">
+          {dayDiary.hashTag2}
+        </S.TagText>
       </S.TagBox>
     </S.DayBox>
   );


### PR DESCRIPTION
# 개요

기존에 미리 태그가 길 경우를 생각했어야 했는데, 깜빡했다. 
`numberOfLines={1}`, `ellipsizeMode="clip"` 두 개의 props를 추가해줬다.

1줄로 고정해주고, 범위 밖 텍스트를 보이지 않게 해줬다.

---

# 수정 전 후

![Screenshot_1739101911](https://github.com/user-attachments/assets/f2f1f54c-9a9b-454f-8e56-e02a1db2dacb) | ![Screenshot_1739101889](https://github.com/user-attachments/assets/7517f84d-4420-44ed-9057-4ac6ba837963)
---|---|