### PR TITLE
의견 보내기 기능 구현

### DIFF
--- a/src/constants/toastMessage.ts
+++ b/src/constants/toastMessage.ts
@@ -23,6 +23,7 @@ const toastMessage = {
     success: "설정 업데이트 완료.",
     failed: "설정 업데이트 도중 문제 발생.",
   },
+  sendMailFailed: "기본 메일 앱이 설치되어 있는지 확인해주세요.",
   removeAssistant: {
     success: "서포터가 삭제되었습니다.",
     failed: "서포터 삭제에 실패했습니다.",

--- a/src/libs/showToast.ts
+++ b/src/libs/showToast.ts
@@ -13,7 +13,7 @@ const showToast = (message: string | undefined, type: MessageType) => {
         fontSize: parseInt(theme.fontSize.base),
         fontFamily: theme.fontFamily.nsRegular,
       },
-      visibilityTime: 1000,
+      visibilityTime: 1500,
     });
   }
 };

--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -9,6 +9,8 @@ import Loading from "@/src/components/ui/Loading";
 import useUpdateSetting from "@/src/hooks/useUpdateSetting";
 import useLogout from "@/src/hooks/useLogout";
 import useDeleteAccount from "@/src/hooks/useDeleteAccount";
+import showToast from "@/src/libs/showToast";
+import toastMessage from "@/src/constants/toastMessage";
 import { UserSettingResult } from "@/src/types/settingTypes";
 import { theme } from "@/src/constants/theme";
 import * as S from "./styles";
@@ -58,6 +60,18 @@ function SettingPage({ data }: Props): JSX.Element {
 
   const handlePrevButton = () => {
     router.back();
+  };
+
+  const handleSendMail = async () => {
+    try {
+      const data = await Linking.openURL(
+        "mailto: teammelissa7@gmail.com?subject=[Melissa] 제목을 작성해주세요.&body=내용을 작성해주세요."
+      );
+      console.log(data);
+    } catch (e) {
+      console.error(e);
+      showToast(toastMessage.sendMailFailed, "error");
+    }
   };
 
   const handleDonation = () => {
@@ -126,7 +140,7 @@ function SettingPage({ data }: Props): JSX.Element {
             <S.ItemValueText>{notificationTime.slice(0, -3)}</S.ItemValueText>
           </S.ItemButton>
 
-          <S.ItemButton hitSlop={10}>
+          <S.ItemButton hitSlop={10} onPress={handleSendMail}>
             <S.ItemTitleBox>
               <S.ItemTitleText>의견 보내기</S.ItemTitleText>
               <S.ItemDescriptionText>운영진에게 앱에 대한 의견을</S.ItemDescriptionText>


### PR DESCRIPTION
# 개요

`expo-mail-composer` 라이브러리에 알 수 없는 문제가 존재해 메일 앱이 열리지 않고 크래시 발생

→ `expo-linking` 라이브러리를 활용해 `mailto:`로 메일 앱 오픈하도록 구현

---

## 구현

- [X] 기본 메일 앱이 존재하면, 해당 앱으로 이동시키며 제목, 본문, 수신자가 기본값으로 세팅되도록 구현
- [X] 각 OS의 기본 메일 앱이 존재하지 않으면, 토스트 메시지로 안내하도록 구현
- [X] 토스트 메시지가 1초만에 닫히는게 빠른 것 같아서, 1.5초로 증가시킴

---

## 구현 결과

https://github.com/user-attachments/assets/9d70880e-788f-41bf-8651-020237d57e80

---