### PR TITLE
회원탈퇴 버튼에 정말 탈퇴할지 물어보는 Alert 추가

### DIFF
--- a/src/pages/Setting/index.tsx
+++ b/src/pages/Setting/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ScrollView, Switch } from "react-native";
+import { Alert, ScrollView, Switch } from "react-native";
 import { useRouter } from "expo-router";
 import * as Linking from "expo-linking";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
@@ -83,7 +83,15 @@ function SettingPage({ data }: Props): JSX.Element {
   };
 
   const handleDeleteAccount = () => {
-    deleteAccountMutate();
+    Alert.alert(
+      "회원탈퇴",
+      "정말 탈퇴하시겠습니까?",
+      [
+        { text: "취소", style: "cancel" },
+        { text: "탈퇴", style: "destructive", onPress: () => deleteAccountMutate() },
+      ],
+      { cancelable: true }
+    );
   };
 
   const handleNotificationSummary = () => {


### PR DESCRIPTION
# 개요

기존에는 탈퇴하기 버튼 클릭 시 바로 탈퇴되어, 사용자가 로그아웃하려다 실수로 탈퇴하는 등의 문제가 발생할 수 있었다.
이를 개선하기 위해 탈퇴하기 버튼 클릭 시 `Alert`를 사용해 정말 탈퇴할지 한 번 더 물어보도록 단계를 추가했다.

---

## 구현

- [X] 회원탈퇴 버튼에 Confirm alert 추가

---

## 구현 결과

https://github.com/user-attachments/assets/49696695-f848-4a34-be1c-58a04983d65d

---