### PR TITLE
이미지 캐싱 기능 구현, 캘린더 dayComponent 리렌더링 최적화

### DIFF
--- a/src/components/AssistantList/AssistantCard/ProfileImage/index.tsx
+++ b/src/components/AssistantList/AssistantCard/ProfileImage/index.tsx
@@ -7,7 +7,7 @@ interface Props {
 function ProfileImage({ url }: Props) {
   return (
     <S.ImageBox>
-      <S.Image source={{ uri: url }} />
+      <S.Image src={url} />
     </S.ImageBox>
   );
 }

--- a/src/components/AssistantList/AssistantCard/ProfileImage/styles.ts
+++ b/src/components/AssistantList/AssistantCard/ProfileImage/styles.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components/native";
+import CachedImage from "@/src/components/ui/CachedImage";
 import responsiveToPx from "@/src/utils/responsiveToPx";
 
 export const ImageBox = styled.View`
@@ -10,7 +11,7 @@ export const ImageBox = styled.View`
   align-items: center;
 `;
 
-export const Image = styled.Image`
+export const Image = styled(CachedImage)`
   width: ${responsiveToPx("295px")};
   height: ${responsiveToPx("295px")};
   border-radius: 5px;

--- a/src/components/AssistantList/AssistantCard/styles.ts
+++ b/src/components/AssistantList/AssistantCard/styles.ts
@@ -11,7 +11,7 @@ export const NameTagContainer = styled.View`
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding-horizontal: ${responsiveToPx("20px")};
+  padding: 0px ${responsiveToPx("20px")};
 `;
 
 /* 복제 및 삭제 버튼 아이콘 정렬 */
@@ -23,11 +23,11 @@ export const IconButtonBox = styled.View`
 
 /* "+" 버튼을 포함한 컨테이너 */
 export const ButtonBox = styled.View`
-  flex-direction: row;
-  gap: ${({ theme }) => theme.gap.lg};
-  align-items: center;
-  justify-content: center;
   width: 100%;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: ${({ theme }) => theme.gap.lg};
 `;
 
 /* 터치 가능한 버튼 */

--- a/src/components/ui/CachedImage/index.tsx
+++ b/src/components/ui/CachedImage/index.tsx
@@ -1,0 +1,31 @@
+import * as FileSystem from "expo-file-system";
+import { Image } from "react-native";
+import { useEffect, useState } from "react";
+import { CachedImageProps } from "./types";
+
+function CachedImage({ src, ...rest }: CachedImageProps): JSX.Element {
+  const [cachedSource, setCachedSource] = useState<undefined | { uri: string }>(undefined);
+
+  // https://.../ai-profile/8ba80263-cf09-41f3-b5c4-113b3e5476d5 와 같은 경로를 넣으면,
+  // 8ba80263-cf09-41f3-b5c4-113b3e5476d5를 파일명으로 사용
+  const fileName = src.split("/").pop();
+  const cachedUri = `${FileSystem.cacheDirectory}${fileName}.png`;
+
+  useEffect(() => {
+    const checkCacheAndDownload = async () => {
+      const info = await FileSystem.getInfoAsync(cachedUri);
+      if (!info.exists) {
+        console.log("기존 캐시된 이미지 X, 다운로드중...");
+        await FileSystem.downloadAsync(src, cachedUri);
+      }
+      console.log("캐시된 이미지 사용");
+      setCachedSource({ uri: cachedUri });
+    };
+
+    checkCacheAndDownload();
+  }, [cachedUri, src]);
+
+  return <Image source={cachedSource} {...rest} />;
+}
+
+export default CachedImage;

--- a/src/components/ui/CachedImage/index.tsx
+++ b/src/components/ui/CachedImage/index.tsx
@@ -1,5 +1,5 @@
 import * as FileSystem from "expo-file-system";
-import { Image } from "react-native";
+import { Image } from "expo-image";
 import { useEffect, useState } from "react";
 import { CachedImageProps } from "./types";
 

--- a/src/components/ui/CachedImage/types.ts
+++ b/src/components/ui/CachedImage/types.ts
@@ -1,3 +1,3 @@
-import { ImageProps } from "react-native";
+import { ImageProps } from "expo-image";
 
 export type CachedImageProps = ImageProps & { src: string };

--- a/src/components/ui/CachedImage/types.ts
+++ b/src/components/ui/CachedImage/types.ts
@@ -1,0 +1,3 @@
+import { ImageProps } from "react-native";
+
+export type CachedImageProps = ImageProps & { src: string };

--- a/src/hooks/useCurrentDate.ts
+++ b/src/hooks/useCurrentDate.ts
@@ -37,6 +37,7 @@ const useCurrentDate = () => {
       queryClient.prefetchQuery({
         queryFn: () => getDiariesFn(curYear, curMonth),
         queryKey: ["diaries", curYear, curMonth],
+        staleTime: 5 * 60 * 1000,
       });
       // 3개월 캘린더 데이터를 flat
       const flattedData = result

--- a/src/pages/Calendar/DayComponent/index.tsx
+++ b/src/pages/Calendar/DayComponent/index.tsx
@@ -1,15 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { BasicDayProps } from "react-native-calendars/src/calendar/day/basic";
 import { DateData } from "react-native-calendars";
-import { Day } from "@/src/types/calendarTypes";
+import { MonthCalendar } from "@/src/types/calendarTypes";
 import * as S from "./styles";
 
-interface Props {
-  date: DateData;
-  calendars?: Day[];
-  onPress: () => void;
+interface Props extends Omit<BasicDayProps, "date"> {
+  date?: DateData;
 }
 
-function DayComponent({ date, calendars, onPress }: Props): JSX.Element {
-  const dayDiary = calendars?.find(
+function DayComponent({ date, onPress }: Props): JSX.Element | null {
+  const { data } = useQuery<MonthCalendar>({
+    queryKey: ["calendar", date?.year, date?.month],
+  });
+
+  if (!date || !data) return null;
+
+  const dayDiary = data.result.find(
     (calendar) =>
       calendar.year === date.year && calendar.month === date.month && calendar.day === date.day
   );
@@ -25,7 +31,7 @@ function DayComponent({ date, calendars, onPress }: Props): JSX.Element {
   }
 
   return (
-    <S.DayBox onPress={onPress}>
+    <S.DayBox onPress={() => onPress && onPress(date)}>
       <S.ImageBox>
         <S.Image src={dayDiary.imageS3} />
       </S.ImageBox>

--- a/src/pages/Calendar/DayComponent/index.tsx
+++ b/src/pages/Calendar/DayComponent/index.tsx
@@ -13,7 +13,7 @@ function DayComponent({ date, onPress }: Props): JSX.Element | null {
     queryKey: ["calendar", date?.year, date?.month],
   });
 
-  if (!date || !data) return null;
+  if (!date || !data || !onPress) return null;
 
   const dayDiary = data.result.find(
     (calendar) =>
@@ -31,7 +31,7 @@ function DayComponent({ date, onPress }: Props): JSX.Element | null {
   }
 
   return (
-    <S.DayBox onPress={() => onPress && onPress(date)}>
+    <S.DayBox onPress={() => onPress(date)}>
       <S.ImageBox>
         <S.Image src={dayDiary.imageS3} />
       </S.ImageBox>

--- a/src/pages/Calendar/DayComponent/styles.ts
+++ b/src/pages/Calendar/DayComponent/styles.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components/native";
-import { Image as Img } from "react-native";
+import CachedImage from "@/src/components/ui/CachedImage";
 import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 
 export const DayBox = styled.TouchableOpacity`
@@ -16,7 +16,7 @@ export const ImageBox = styled.View`
   overflow: hidden;
 `;
 
-export const Image = styled(Img)`
+export const Image = styled(CachedImage)`
   width: ${responsiveToPxByHeight("54px")};
   height: ${responsiveToPxByHeight("54px")};
 `;

--- a/src/pages/Calendar/DiaryBottomSheet/index.tsx
+++ b/src/pages/Calendar/DiaryBottomSheet/index.tsx
@@ -3,10 +3,10 @@ import { ForwardedRef, forwardRef, useMemo } from "react";
 import { useRouter } from "expo-router";
 import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps } from "@gorhom/bottom-sheet";
 import { DateData } from "react-native-calendars";
+import { preventDoublePress } from "@/src/libs/esToolkit";
 import { DiariesResult } from "@/src/types/calendarTypes";
 import { shadowProps } from "@/src/constants/shadowProps";
 import * as S from "./styles";
-import { preventDoublePress } from "@/src/libs/esToolkit";
 
 interface Props {
   pressedDate: Pick<DateData, "year" | "month" | "day">;
@@ -29,6 +29,8 @@ function DiaryBottomSheet({ pressedDate }: Props, ref: ForwardedRef<BottomSheet>
     router.push(`/(app)/chatting?year=${year}&month=${month}&day=${day}`)
   );
 
+  const diary = data?.result.find((d) => d.day === day);
+
   return (
     <BottomSheet
       ref={ref}
@@ -40,23 +42,19 @@ function DiaryBottomSheet({ pressedDate }: Props, ref: ForwardedRef<BottomSheet>
       enablePanDownToClose={true}
       backdropComponent={Backdrop}
     >
-      {data && (
+      {diary && (
         <S.BottomSheetLayout>
           <S.ScrollBox showsVerticalScrollIndicator={false}>
             <S.ImageBox>
-              <S.Image source={{ uri: data.result.find((d) => d.day === day)?.imageS3 }} />
+              <S.Image src={diary.imageS3} />
             </S.ImageBox>
             <S.DateText>
-              {data.result.find((d) => d.day === day)?.year}.{" "}
-              {data.result.find((d) => d.day === day)?.month}.{" "}
-              {data.result.find((d) => d.day === day)?.day}
+              {diary.year}. {diary.month}. {diary.day}
             </S.DateText>
-            <S.TitleText>{data.result.find((d) => d.day === day)?.summaryTitle}</S.TitleText>
-            <S.ContentText>{data.result.find((d) => d.day === day)?.summaryContent}</S.ContentText>
-
+            <S.TitleText>{diary.summaryTitle}</S.TitleText>
+            <S.ContentText>{diary.summaryContent}</S.ContentText>
             <S.TagText>
-              {data.result.find((d) => d.day === day)?.hashTag1}{" "}
-              {data.result.find((d) => d.day === day)?.hashTag2}
+              {diary.hashTag1} {diary.hashTag2}
             </S.TagText>
             <S.ChatButtonBox>
               <S.ViewChatButton

--- a/src/pages/Calendar/DiaryBottomSheet/styles.ts
+++ b/src/pages/Calendar/DiaryBottomSheet/styles.ts
@@ -1,5 +1,6 @@
 import styled from "styled-components/native";
 import { BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import CachedImage from "@/src/components/ui/CachedImage";
 import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 import { theme } from "@/src/constants/theme";
 
@@ -24,7 +25,7 @@ export const ImageBox = styled.View`
   overflow: hidden;
 `;
 
-export const Image = styled.Image`
+export const Image = styled(CachedImage)`
   width: 100%;
   height: 100%;
 `;

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -50,9 +50,11 @@ function CalendarPage(): JSX.Element {
   const handleDayPress = (date: DateData) => {
     const { year, month, day } = date;
     setPressedDate({ year, month, day });
-    if (bottomSheetRef.current) {
-      bottomSheetRef.current.expand();
-    }
+    setTimeout(() => {
+      if (bottomSheetRef.current) {
+        bottomSheetRef.current.expand();
+      }
+    }, 0);
   };
 
   return (

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -42,7 +42,7 @@ function CalendarPage(): JSX.Element {
   }));
 
   const router = useRouter();
-  const { calendarsData, changeDate } = useCurrentDate();
+  const { changeDate } = useCurrentDate();
   const bottomSheetRef = useRef<BottomSheet>(null); // BottomSheet(자식 컴포넌트)를 조작하기 위한 부모 ref
 
   const handleSettingPress = preventDoublePress(() => router.push("/(app)/setting"));
@@ -73,16 +73,8 @@ function CalendarPage(): JSX.Element {
             <MaterialIcons name="settings" size={24} color={theme.colors.calendarIcon} />
           )
         }
-        dayComponent={({ date }) => {
-          if (!date) return undefined;
-          return (
-            <DayComponent
-              date={date}
-              calendars={calendarsData}
-              onPress={() => handleDayPress(date)}
-            />
-          );
-        }}
+        onDayPress={handleDayPress}
+        dayComponent={DayComponent}
       />
       <ChatButton />
       <DiaryBottomSheet ref={bottomSheetRef} pressedDate={pressedDate} />

--- a/src/pages/Chatting/AiChatBox/index.tsx
+++ b/src/pages/Chatting/AiChatBox/index.tsx
@@ -9,7 +9,7 @@ interface Props {
 function AiChatBox({ content, imageUrl }: Props): JSX.Element {
   return (
     <S.AiChatLayout>
-      <S.Image source={{ uri: imageUrl }} />
+      <S.Image src={imageUrl} />
       <S.AiChatBox style={shadowProps}>
         <S.AiChatText>{content}</S.AiChatText>
       </S.AiChatBox>

--- a/src/pages/Chatting/AiChatBox/styles.ts
+++ b/src/pages/Chatting/AiChatBox/styles.ts
@@ -1,6 +1,6 @@
-import { Image as Img } from "react-native";
 import styled from "styled-components/native";
 import responsiveToPx from "@/src/utils/responsiveToPx";
+import CachedImage from "@/src/components/ui/CachedImage";
 
 export const AiChatLayout = styled.View`
   flex-direction: row;
@@ -9,7 +9,7 @@ export const AiChatLayout = styled.View`
   gap: ${({ theme }) => theme.gap.md};
 `;
 
-export const Image = styled(Img)`
+export const Image = styled(CachedImage)`
   width: ${responsiveToPx("36px")};
   height: ${responsiveToPx("36px")};
   border-radius: 9999px;

--- a/src/pages/Chatting/index.tsx
+++ b/src/pages/Chatting/index.tsx
@@ -223,7 +223,7 @@ function ChattingPage({ threadDate, expiredDate, readonly }: Props): JSX.Element
             <MaterialIcons name="arrow-back-ios" size={28} color={theme.colors.black} />
           </S.BackButton>
           <S.HeaderButton onPress={handleHeaderPress} hitSlop={7} disabled={readonly}>
-            <S.Image source={{ uri: data.result.aiProfileImageS3 }} />
+            <S.Image src={data.result.aiProfileImageS3} />
             <S.AiNameText>{data.result.aiProfileName}</S.AiNameText>
           </S.HeaderButton>
         </S.HeaderBox>

--- a/src/pages/Chatting/styles.ts
+++ b/src/pages/Chatting/styles.ts
@@ -1,6 +1,7 @@
 import { ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Image as Img } from "expo-image";
+import CachedImage from "@/src/components/ui/CachedImage";
 import styled from "styled-components/native";
 import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 
@@ -36,7 +37,7 @@ export const HeaderButton = styled.TouchableOpacity`
   align-items: center;
 `;
 
-export const Image = styled.Image`
+export const Image = styled(CachedImage)`
   width: ${responsiveToPx("48px")};
   height: ${responsiveToPx("48px")};
   border-radius: 9999px;


### PR DESCRIPTION
# 개요

S3 이미지 주소를 파싱해서 아이폰/안드로이드폰 캐시 디렉토리에 이미지를 다운로드 하는 방식으로 하나의 이미지는 한 번만 요청을 수행하도록 구현해, S3로의 요청을 감소시키고 이미지 로드 속도를 향상시켰다.

그리고 예전에 임시책으로 React Native 기본 Image 컴포넌트를 사용해 해결했던 캘린더 페이지의 `dayComponent` 리렌더링 문제를 근본적으로 해결했다.

---

## 구현

- [X] 존재하지 않는 이미지를 캐시 디렉토리에 다운로드하고, 이를 불러와 렌더링하는 `CachedImage` 컴포넌트 구현
- [X] AI 응답이 생성 중일 때 새로운 채팅을 전송하지 못하도록 flag 도입해 대화 로직 안정성 향상
- [X] 채팅 페이지에 이미지 캐싱 적용
- [X] AI 프로필 카드에 이미지 캐싱 적용
- [X] 캘린더 `dayComponent`에 이미지 캐싱 적용
    - [X] 캘린더의 `dayComponent`에서 지속적으로 발생하던 리렌더링 문제 해결 [github issue](https://github.com/wix/react-native-calendars/issues/2275)
- [X] 일기 바텀 시트 이미지가 잠시 이전 이미지로 보여지는 문제를 `setTimeout(() => {}, 0)`을 활용해 `callback queue`로 보내 `call stack`이 완전히 빈 후에 실행되도록 구현해 해결

---

## 이미지 캐싱 적용 전 / 후

https://github.com/user-attachments/assets/93b3b6b4-5fe6-4c5e-9303-cf95cc0bb55e

https://github.com/user-attachments/assets/82f38452-9a2d-481a-aee5-8b53b55338f7

---

## 캘린더의 `dayComponent` 리렌더링 문제 해결 전 / 후

| ![before_daycomponent_edit](https://github.com/user-attachments/assets/c163b9bc-6e66-4cfb-b73e-54bd9dacb059) | ![after_daycomponent_edit](https://github.com/user-attachments/assets/9e72a262-9565-4bdb-a114-d616871f4adc) |
|--|--|

---