### PR TITLE
바텀 시트를 열어두고, 뒤로가기 버튼 클릭 시 앱이 종료되는 문제 해결

### DIFF
--- a/src/pages/Calendar/DiaryBottomSheet/index.tsx
+++ b/src/pages/Calendar/DiaryBottomSheet/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { ForwardedRef, forwardRef, useMemo } from "react";
+import { type Dispatch, type ForwardedRef, type SetStateAction, forwardRef, useMemo } from "react";
 import { useRouter } from "expo-router";
 import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps } from "@gorhom/bottom-sheet";
 import { DateData } from "react-native-calendars";
@@ -10,9 +10,13 @@ import * as S from "./styles";
 
 interface Props {
   pressedDate: Pick<DateData, "year" | "month" | "day">;
+  setIsBottomSheetOpen: Dispatch<SetStateAction<boolean>>;
 }
 
-function DiaryBottomSheet({ pressedDate }: Props, ref: ForwardedRef<BottomSheet>): JSX.Element {
+function DiaryBottomSheet(
+  { pressedDate, setIsBottomSheetOpen }: Props,
+  ref: ForwardedRef<BottomSheet>
+): JSX.Element {
   const { year, month, day } = pressedDate;
   const router = useRouter();
   const snapPoints = useMemo(() => ["60%", "90%"], []);
@@ -41,6 +45,7 @@ function DiaryBottomSheet({ pressedDate }: Props, ref: ForwardedRef<BottomSheet>
       enableDynamicSizing={false}
       enablePanDownToClose={true}
       backdropComponent={Backdrop}
+      onChange={(idx) => setIsBottomSheetOpen(idx > -1)}
     >
       {diary && (
         <S.BottomSheetLayout>

--- a/src/pages/Calendar/DiaryBottomSheet/useBottomSheetBackHandler.ts
+++ b/src/pages/Calendar/DiaryBottomSheet/useBottomSheetBackHandler.ts
@@ -1,0 +1,28 @@
+import type BottomSheet from "@gorhom/bottom-sheet";
+import { useFocusEffect } from "expo-router";
+import { type RefObject, useCallback } from "react";
+import { BackHandler } from "react-native";
+
+type TProps = {
+  isBottomSheetOpen: boolean;
+  bottomSheetRef: RefObject<BottomSheet>;
+};
+
+// TODO: 디렉토리 구조 개편 작업 때 이전될 예정
+export const useBottomSheetBackHandler = ({ isBottomSheetOpen, bottomSheetRef }: TProps) => {
+  useFocusEffect(
+    useCallback(() => {
+      const onBackPress = () => {
+        if (isBottomSheetOpen) {
+          bottomSheetRef.current?.close();
+          return true;
+        } else {
+          return false;
+        }
+      };
+      BackHandler.addEventListener("hardwareBackPress", onBackPress);
+
+      return () => BackHandler.removeEventListener("hardwareBackPress", onBackPress);
+    }, [bottomSheetRef, isBottomSheetOpen])
+  );
+};

--- a/src/pages/Calendar/index.tsx
+++ b/src/pages/Calendar/index.tsx
@@ -9,6 +9,7 @@ import ChatButton from "./ChatButton";
 import DiaryBottomSheet from "./DiaryBottomSheet";
 import { preventDoublePress } from "@/src/libs/esToolkit";
 import { theme } from "@/src/constants/theme";
+import { useBottomSheetBackHandler } from "./DiaryBottomSheet/useBottomSheetBackHandler";
 import * as S from "./styles";
 
 LocaleConfig.locales["ko"] = {
@@ -34,13 +35,13 @@ LocaleConfig.locales["ko"] = {
 LocaleConfig.defaultLocale = "ko";
 
 function CalendarPage(): JSX.Element {
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState<boolean>(false);
   // 초기값은 오늘로
   const [pressedDate, setPressedDate] = useState<Pick<DateData, "year" | "month" | "day">>(() => ({
     year: new Date().getFullYear(),
     month: new Date().getMonth() + 1,
     day: new Date().getDate(),
   }));
-
   const router = useRouter();
   const { changeDate } = useCurrentDate();
   const bottomSheetRef = useRef<BottomSheet>(null); // BottomSheet(자식 컴포넌트)를 조작하기 위한 부모 ref
@@ -56,6 +57,9 @@ function CalendarPage(): JSX.Element {
       }
     }, 0);
   };
+
+  // fix: 안드로이드에서 뒤로가기 물리 버튼 누르면 앱 꺼지던 문제 수정
+  useBottomSheetBackHandler({ isBottomSheetOpen, bottomSheetRef });
 
   return (
     <S.SafeView>
@@ -79,7 +83,11 @@ function CalendarPage(): JSX.Element {
         dayComponent={DayComponent}
       />
       <ChatButton />
-      <DiaryBottomSheet ref={bottomSheetRef} pressedDate={pressedDate} />
+      <DiaryBottomSheet
+        ref={bottomSheetRef}
+        pressedDate={pressedDate}
+        setIsBottomSheetOpen={setIsBottomSheetOpen}
+      />
     </S.SafeView>
   );
 }


### PR DESCRIPTION
## 👀 관련 이슈

close #32

## ✨ 작업한 내용

현재 사용하고 있는 [react-native-bottom-sheet](https://gorhom.dev/react-native-bottom-sheet/)에는 뒤로가기 버튼과 바텀 시트를 매핑하는 props를 제공하지 않습니다..ㅠㅠ
대신 간단하게 구현할 수 있는 방법들이 많이 논의되고 있어 다행히 쉽게 해결할 수 있었습니다. [참조 github issue](https://github.com/gorhom/react-native-bottom-sheet/issues/556#issuecomment-1019073447)

<img width="837" alt="스크린샷 2025-03-19 23 29 33" src="https://github.com/user-attachments/assets/aaffd15e-02c8-4eaf-b2c1-70f2786c71a5" />

위 방식이 현재 멜리사의 컴포넌트 구조와 가장 잘 통합될 수 있을 것 같아 적용했고, 잘 작동하는 것을 확인했습니다.

- [X] useBottomSheetBackHandler 커스텀 훅을 도입해 뒤로가기 버튼 동작을 조건부로 제어

## 📷스크린샷 / 영상

https://github.com/user-attachments/assets/64a76606-6826-4a3d-8204-338533035e6f