### PR TITLE
채팅 페이지에 안내 텍스트 추가 및 채팅 인풋 레이아웃 개선

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -5,7 +5,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: "Melissa",
   slug: "melissa",
   owner: "teammelissa7",
-  version: "1.0.0",
+  version: "1.0.1",
   orientation: "portrait",
   icon: "./assets/images/icon.png",
   scheme: "myapp",

--- a/src/app/(app)/chatting.tsx
+++ b/src/app/(app)/chatting.tsx
@@ -4,9 +4,9 @@ import CommonError from "@/src/components/ui/CommonError";
 import Loading from "@/src/components/ui/Loading";
 import { setAiProfileId } from "@/src/libs/mmkv";
 import ChattingContainer from "@/src/features/chatting/containers/ChattingContainer";
+import AssistantListContainer from "@/src/features/assistantList/containers/AssistantListContainer";
 import { useInitializeChatting } from "@/src/features/chatting/hooks/useInitializeChatting";
 import { readOnlyTypeGuard } from "@/src/features/chatting/utils/readOnlyTypeGuard";
-import AssistantListContainer from "@/src/features/assistantList/containers/AssistantListContainer";
 
 export default function ChattingRouter(): JSX.Element | null {
   const [isVisible, setIsVisible] = useState<boolean>(false);
@@ -22,7 +22,16 @@ export default function ChattingRouter(): JSX.Element | null {
 
   // readonly 채팅방이 필요한 경우
   if (readOnlyTypeGuard(readOnlyDate)) {
-    return <ChattingContainer threadDate={readOnlyDate} threadExpiredDate={new Date()} readonly={true} />;
+    return (
+      <ChattingContainer
+        threadDate={readOnlyDate}
+        threadExpiredDate={new Date()}
+        readonly={true}
+        renderAssistantList={({ isVisible, setIsVisible, onPressAiCard }) => (
+          <AssistantListContainer isVisible={isVisible} setIsVisible={setIsVisible} onPressAiCard={onPressAiCard} />
+        )}
+      />
+    );
   }
 
   if (!threadDate || !threadExpiredDate) {
@@ -41,7 +50,15 @@ export default function ChattingRouter(): JSX.Element | null {
     );
   }
 
-  return <ChattingContainer threadDate={threadDate} threadExpiredDate={threadExpiredDate} />;
+  return (
+    <ChattingContainer
+      threadDate={threadDate}
+      threadExpiredDate={threadExpiredDate}
+      renderAssistantList={({ isVisible, setIsVisible, onPressAiCard }) => (
+        <AssistantListContainer isVisible={isVisible} setIsVisible={setIsVisible} onPressAiCard={onPressAiCard} />
+      )}
+    />
+  );
 }
 
 const FlexView = styled.View`

--- a/src/features/chatting/components/ChatHeader.tsx
+++ b/src/features/chatting/components/ChatHeader.tsx
@@ -1,0 +1,64 @@
+import styled from "styled-components/native";
+import { useRouter } from "expo-router";
+import { MaterialIcons } from "@expo/vector-icons";
+import CachedImage from "@/src/components/ui/CachedImage";
+import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
+import { theme } from "@/src/constants/theme";
+
+type ChatHeaderProps = {
+  imageSrc: string;
+  assistantName: string;
+  onPress: () => void;
+  readonly?: boolean;
+};
+
+export default function ChatHeader({ imageSrc, assistantName, onPress, readonly }: ChatHeaderProps) {
+  const router = useRouter();
+
+  return (
+    <HeaderBox>
+      <BackButton onPress={() => router.back()} hitSlop={7}>
+        <MaterialIcons name="arrow-back-ios" size={28} color={theme.colors.black} />
+      </BackButton>
+      <HeaderButton onPress={onPress} hitSlop={7} disabled={readonly}>
+        <Image src={imageSrc} />
+        <AiNameText>{assistantName}</AiNameText>
+      </HeaderButton>
+    </HeaderBox>
+  );
+}
+
+const HeaderBox = styled.View`
+  width: 100%;
+  height: ${responsiveToPxByHeight("110px")};
+  background-color: ${({ theme }) => theme.colors.white};
+  flex-direction: row;
+  padding: 0px ${responsiveToPx("24px")};
+  align-items: center;
+  gap: ${({ theme }) => theme.gap.lg};
+`;
+
+const BackButton = styled.TouchableOpacity`
+  width: ${responsiveToPx("28px")};
+  height: ${responsiveToPx("28px")};
+  justify-content: center;
+  align-items: center;
+`;
+
+const HeaderButton = styled.TouchableOpacity`
+  flex-direction: row;
+  gap: ${({ theme }) => theme.gap.lg};
+  align-items: center;
+`;
+
+const Image = styled(CachedImage)`
+  width: ${responsiveToPx("48px")};
+  height: ${responsiveToPx("48px")};
+  border-radius: 9999px;
+`;
+
+const AiNameText = styled.Text`
+  color: ${({ theme }) => theme.colors.black};
+  font-family: ${({ theme }) => theme.fontFamily.nsBold};
+  font-size: ${({ theme }) => theme.fontSize.lg};
+`;

--- a/src/features/chatting/components/ChatInput.tsx
+++ b/src/features/chatting/components/ChatInput.tsx
@@ -34,7 +34,7 @@ export default function ChatInput({ input, setInput, onSubmitPress, readonly }: 
           <ButtonImage source={require("@/assets/images/chatButton.png")} />
         </ChatButton>
       </ChatInputBox>
-      <InfoText> {!isKeyboardOpen && "뒤로 가기 버튼을 누르면 대화가 자동으로 요약됩니다"}</InfoText>
+      <InfoText>{!isKeyboardOpen && "뒤로 가기 버튼을 누르면 대화가 자동으로 요약됩니다"}</InfoText>
     </KeyboardAvoidingBox>
   );
 }

--- a/src/features/chatting/components/ChatInput.tsx
+++ b/src/features/chatting/components/ChatInput.tsx
@@ -51,6 +51,7 @@ const ChatInputBox = styled.View<{ $isKeyboardOpen: boolean }>`
   flex-direction: row;
   justify-content: center;
   align-items: flex-end;
+  padding-top: ${responsiveToPx("10px")};
   gap: ${({ theme }) => theme.gap.md};
   padding-bottom: ${({ $isKeyboardOpen }) => ($isKeyboardOpen ? "0px" : responsiveToPx("40px"))};
 `;

--- a/src/features/chatting/components/ChatInput.tsx
+++ b/src/features/chatting/components/ChatInput.tsx
@@ -1,10 +1,11 @@
 import { Platform } from "react-native";
+import type { Dispatch, SetStateAction } from "react";
 import styled from "styled-components/native";
 import { Image as Img } from "expo-image";
-import responsiveToPx from "@/src/utils/responsiveToPx";
+import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 import { shadowProps } from "@/src/constants/shadowProps";
 import { theme } from "@/src/constants/theme";
-import { Dispatch, SetStateAction } from "react";
+import { useIsKeyboardOpen } from "../hooks/useIsKeyboardOpen";
 
 type ChatInputProps = {
   input: string;
@@ -14,29 +15,33 @@ type ChatInputProps = {
 };
 
 export default function ChatInput({ input, setInput, onSubmitPress, readonly }: ChatInputProps) {
+  const isKeyboardOpen = useIsKeyboardOpen();
+
+  if (readonly) return null;
+
   return (
-    <KeyboardAvoidingBox behavior={Platform.OS === "ios" ? "padding" : "height"}>
-      {!readonly && (
-        <ChatInputBox>
-          <StyledChatInput
-            placeholder="오늘 하루에 대해 말해주세요"
-            multiline={true}
-            value={input}
-            onChangeText={(e) => setInput(e)}
-            hitSlop={15}
-            placeholderTextColor={theme.colors.placeholderText}
-          />
-          <ChatButton hitSlop={15} style={shadowProps} onPress={onSubmitPress}>
-            <ButtonImage source={require("@/assets/images/chatButton.png")} />
-          </ChatButton>
-        </ChatInputBox>
-      )}
+    <KeyboardAvoidingBox behavior={Platform.OS === "ios" ? "padding" : undefined}>
+      <ChatInputBox>
+        <StyledChatInput
+          placeholder="오늘 하루에 대해 말해주세요"
+          multiline={true}
+          value={input}
+          onChangeText={(e) => setInput(e)}
+          hitSlop={15}
+          placeholderTextColor={theme.colors.placeholderText}
+        />
+        <ChatButton hitSlop={15} style={shadowProps} onPress={onSubmitPress}>
+          <ButtonImage source={require("@/assets/images/chatButton.png")} />
+        </ChatButton>
+      </ChatInputBox>
+      <InfoText> {!isKeyboardOpen && "뒤로 가기 버튼을 누르면 대화가 자동으로 요약됩니다"}</InfoText>
     </KeyboardAvoidingBox>
   );
 }
 
 const KeyboardAvoidingBox = styled.KeyboardAvoidingView`
   width: 100%;
+  background-color: ${({ theme }) => theme.colors.whiteBlue};
   justify-content: center;
   align-items: center;
 `;
@@ -44,7 +49,6 @@ const KeyboardAvoidingBox = styled.KeyboardAvoidingView`
 const ChatInputBox = styled.View`
   width: 100%;
   min-height: ${responsiveToPx("100px")};
-  background-color: ${({ theme }) => theme.colors.whiteBlue};
   flex-direction: row;
   justify-content: center;
   align-items: flex-end;
@@ -75,4 +79,12 @@ const ChatButton = styled.TouchableOpacity`
 const ButtonImage = styled(Img)`
   width: 120%;
   height: 120%;
+`;
+
+const InfoText = styled.Text`
+  text-align: center;
+  bottom: ${responsiveToPxByHeight("30px")};
+  color: ${({ theme }) => theme.colors.assistantChat};
+  font-family: ${({ theme }) => theme.fontFamily.nsRegular};
+  font-size: ${({ theme }) => theme.fontSize.xs};
 `;

--- a/src/features/chatting/components/ChatInput.tsx
+++ b/src/features/chatting/components/ChatInput.tsx
@@ -1,0 +1,78 @@
+import { Platform } from "react-native";
+import styled from "styled-components/native";
+import { Image as Img } from "expo-image";
+import responsiveToPx from "@/src/utils/responsiveToPx";
+import { shadowProps } from "@/src/constants/shadowProps";
+import { theme } from "@/src/constants/theme";
+import { Dispatch, SetStateAction } from "react";
+
+type ChatInputProps = {
+  input: string;
+  setInput: Dispatch<SetStateAction<string>>;
+  onSubmitPress: () => void;
+  readonly?: boolean;
+};
+
+export default function ChatInput({ input, setInput, onSubmitPress, readonly }: ChatInputProps) {
+  return (
+    <KeyboardAvoidingBox behavior={Platform.OS === "ios" ? "padding" : "height"}>
+      {!readonly && (
+        <ChatInputBox>
+          <StyledChatInput
+            placeholder="오늘 하루에 대해 말해주세요"
+            multiline={true}
+            value={input}
+            onChangeText={(e) => setInput(e)}
+            hitSlop={15}
+            placeholderTextColor={theme.colors.placeholderText}
+          />
+          <ChatButton hitSlop={15} style={shadowProps} onPress={onSubmitPress}>
+            <ButtonImage source={require("@/assets/images/chatButton.png")} />
+          </ChatButton>
+        </ChatInputBox>
+      )}
+    </KeyboardAvoidingBox>
+  );
+}
+
+const KeyboardAvoidingBox = styled.KeyboardAvoidingView`
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ChatInputBox = styled.View`
+  width: 100%;
+  min-height: ${responsiveToPx("100px")};
+  background-color: ${({ theme }) => theme.colors.whiteBlue};
+  flex-direction: row;
+  justify-content: center;
+  align-items: flex-end;
+  gap: ${({ theme }) => theme.gap.md};
+  padding-bottom: ${responsiveToPx("40px")};
+`;
+
+const StyledChatInput = styled.TextInput`
+  width: ${responsiveToPx("333px")};
+  max-height: ${responsiveToPx("100px")};
+  padding: ${responsiveToPx("11px")} ${responsiveToPx("16px")};
+  background-color: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${({ theme }) => theme.colors.gray};
+  border-radius: ${({ theme }) => theme.borderRadius.sm};
+  font-family: ${({ theme }) => theme.fontFamily.nsRegular};
+  font-size: ${({ theme }) => theme.fontSize.base};
+`;
+
+const ChatButton = styled.TouchableOpacity`
+  width: ${responsiveToPx("44px")};
+  height: ${responsiveToPx("44px")};
+  border-radius: 9999px;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+`;
+
+const ButtonImage = styled(Img)`
+  width: 120%;
+  height: 120%;
+`;

--- a/src/features/chatting/components/ChatInput.tsx
+++ b/src/features/chatting/components/ChatInput.tsx
@@ -21,7 +21,7 @@ export default function ChatInput({ input, setInput, onSubmitPress, readonly }: 
 
   return (
     <KeyboardAvoidingBox behavior={Platform.OS === "ios" ? "padding" : undefined}>
-      <ChatInputBox>
+      <ChatInputBox $isKeyboardOpen={isKeyboardOpen}>
         <StyledChatInput
           placeholder="오늘 하루에 대해 말해주세요"
           multiline={true}
@@ -46,14 +46,13 @@ const KeyboardAvoidingBox = styled.KeyboardAvoidingView`
   align-items: center;
 `;
 
-const ChatInputBox = styled.View`
+const ChatInputBox = styled.View<{ $isKeyboardOpen: boolean }>`
   width: 100%;
-  min-height: ${responsiveToPx("100px")};
   flex-direction: row;
   justify-content: center;
   align-items: flex-end;
   gap: ${({ theme }) => theme.gap.md};
-  padding-bottom: ${responsiveToPx("40px")};
+  padding-bottom: ${({ $isKeyboardOpen }) => ($isKeyboardOpen ? "0px" : responsiveToPx("40px"))};
 `;
 
 const StyledChatInput = styled.TextInput`

--- a/src/features/chatting/containers/ChattingContainer.tsx
+++ b/src/features/chatting/containers/ChattingContainer.tsx
@@ -1,31 +1,38 @@
-import { Fragment, useRef } from "react";
+import { type ReactNode, type Dispatch, type SetStateAction, Fragment, useRef } from "react";
 import { Platform, ScrollView } from "react-native";
 import { useRouter } from "expo-router";
 import { Image as Img } from "expo-image";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import styled from "styled-components/native";
 import { SafeAreaView } from "react-native-safe-area-context";
-
 import Loading from "@/src/components/ui/Loading";
 import CommonError from "@/src/components/ui/CommonError";
 import CachedImage from "@/src/components/ui/CachedImage";
 import { shadowProps } from "@/src/constants/shadowProps";
 import { theme } from "@/src/constants/theme";
 import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
-
 import AiChatBox from "../components/AiChatBox";
 import UserChatBox from "../components/UserChatBox";
 import { useChatting } from "../hooks/useChatting";
 import type { TThreadDate } from "../types/chattingTypes";
-import AssistantListContainer from "../../assistantList/containers/AssistantListContainer";
 
 type ChattingContainerProps = {
   threadDate: TThreadDate;
   threadExpiredDate: Date;
   readonly?: boolean;
+  renderAssistantList: (props: {
+    isVisible: boolean;
+    setIsVisible: Dispatch<SetStateAction<boolean>>;
+    onPressAiCard: (id: number) => void;
+  }) => ReactNode;
 };
 
-export default function ChattingContainer({ threadDate, threadExpiredDate, readonly }: ChattingContainerProps) {
+export default function ChattingContainer({
+  threadDate,
+  threadExpiredDate,
+  renderAssistantList,
+  readonly,
+}: ChattingContainerProps) {
   const router = useRouter();
   const scrollViewRef = useRef<ScrollView>(null);
 
@@ -53,7 +60,7 @@ export default function ChattingContainer({ threadDate, threadExpiredDate, reado
 
   return (
     <Fragment>
-      <AssistantListContainer isVisible={isVisible} setIsVisible={setIsVisible} onPressAiCard={handlePressAiCard} />
+      {renderAssistantList({ isVisible, setIsVisible, onPressAiCard: handlePressAiCard })}
       <SafeView edges={["left", "right", "top"]}>
         <HeaderBox>
           <BackButton onPress={() => router.back()} hitSlop={7}>

--- a/src/features/chatting/containers/ChattingContainer.tsx
+++ b/src/features/chatting/containers/ChattingContainer.tsx
@@ -1,6 +1,5 @@
 import { type ReactNode, type Dispatch, type SetStateAction, Fragment, useRef } from "react";
 import { ScrollView } from "react-native";
-
 import styled from "styled-components/native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import Loading from "@/src/components/ui/Loading";
@@ -11,7 +10,6 @@ import UserChatBox from "../components/UserChatBox";
 import ChatInput from "../components/ChatInput";
 import { useChatting } from "../hooks/useChatting";
 import type { TThreadDate } from "../types/chattingTypes";
-import { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 
 type ChattingContainerProps = {
   threadDate: TThreadDate;
@@ -80,7 +78,6 @@ export default function ChattingContainer({
         </ScrollBox>
         <ChatInput input={input} setInput={setInput} onSubmitPress={handleSubmitPress} readonly={readonly} />
       </SafeView>
-      <InfoText>뒤로 가기 버튼을 누르면 대화가 자동으로 요약됩니다</InfoText>
     </Fragment>
   );
 }
@@ -93,12 +90,4 @@ const SafeView = styled(SafeAreaView)`
 const ScrollBox = styled(ScrollView)`
   flex: 1;
   background-color: ${({ theme }) => theme.colors.whiteBlue};
-`;
-
-const InfoText = styled.Text`
-  text-align: center;
-  bottom: ${responsiveToPxByHeight("30px")};
-  color: ${({ theme }) => theme.colors.assistantChat};
-  font-family: ${({ theme }) => theme.fontFamily.nsRegular};
-  font-size: ${({ theme }) => theme.fontSize.xs};
 `;

--- a/src/features/chatting/containers/ChattingContainer.tsx
+++ b/src/features/chatting/containers/ChattingContainer.tsx
@@ -1,8 +1,6 @@
 import { type ReactNode, type Dispatch, type SetStateAction, Fragment, useRef } from "react";
 import { Platform, ScrollView } from "react-native";
-import { useRouter } from "expo-router";
 import { Image as Img } from "expo-image";
-import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import styled from "styled-components/native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import Loading from "@/src/components/ui/Loading";
@@ -15,6 +13,7 @@ import AiChatBox from "../components/AiChatBox";
 import UserChatBox from "../components/UserChatBox";
 import { useChatting } from "../hooks/useChatting";
 import type { TThreadDate } from "../types/chattingTypes";
+import ChatHeader from "../components/ChatHeader";
 
 type ChattingContainerProps = {
   threadDate: TThreadDate;
@@ -33,7 +32,6 @@ export default function ChattingContainer({
   renderAssistantList,
   readonly,
 }: ChattingContainerProps) {
-  const router = useRouter();
   const scrollViewRef = useRef<ScrollView>(null);
 
   const {
@@ -62,15 +60,12 @@ export default function ChattingContainer({
     <Fragment>
       {renderAssistantList({ isVisible, setIsVisible, onPressAiCard: handlePressAiCard })}
       <SafeView edges={["left", "right", "top"]}>
-        <HeaderBox>
-          <BackButton onPress={() => router.back()} hitSlop={7}>
-            <MaterialIcons name="arrow-back-ios" size={28} color={theme.colors.black} />
-          </BackButton>
-          <HeaderButton onPress={handleHeaderPress} hitSlop={7} disabled={readonly}>
-            <Image src={data.result.aiProfileImageS3} />
-            <AiNameText>{data.result.aiProfileName}</AiNameText>
-          </HeaderButton>
-        </HeaderBox>
+        <ChatHeader
+          imageSrc={data.result.aiProfileImageS3}
+          assistantName={data.result.aiProfileName}
+          onPress={handleHeaderPress}
+          readonly={readonly}
+        />
         <ScrollBox
           ref={scrollViewRef}
           onContentSizeChange={() => {
@@ -110,41 +105,6 @@ export default function ChattingContainer({
 const SafeView = styled(SafeAreaView)`
   flex: 1;
   background-color: ${({ theme }) => theme.colors.white};
-`;
-
-const HeaderBox = styled.View`
-  width: 100%;
-  height: ${responsiveToPxByHeight("110px")};
-  background-color: ${({ theme }) => theme.colors.white};
-  flex-direction: row;
-  padding: 0px ${responsiveToPx("24px")};
-  align-items: center;
-  gap: ${({ theme }) => theme.gap.lg};
-`;
-
-const BackButton = styled.TouchableOpacity`
-  width: ${responsiveToPx("28px")};
-  height: ${responsiveToPx("28px")};
-  justify-content: center;
-  align-items: center;
-`;
-
-const HeaderButton = styled.TouchableOpacity`
-  flex-direction: row;
-  gap: ${({ theme }) => theme.gap.lg};
-  align-items: center;
-`;
-
-const Image = styled(CachedImage)`
-  width: ${responsiveToPx("48px")};
-  height: ${responsiveToPx("48px")};
-  border-radius: 9999px;
-`;
-
-const AiNameText = styled.Text`
-  color: ${({ theme }) => theme.colors.black};
-  font-family: ${({ theme }) => theme.fontFamily.nsBold};
-  font-size: ${({ theme }) => theme.fontSize.lg};
 `;
 
 const ScrollBox = styled(ScrollView)`

--- a/src/features/chatting/containers/ChattingContainer.tsx
+++ b/src/features/chatting/containers/ChattingContainer.tsx
@@ -1,19 +1,17 @@
 import { type ReactNode, type Dispatch, type SetStateAction, Fragment, useRef } from "react";
-import { Platform, ScrollView } from "react-native";
-import { Image as Img } from "expo-image";
+import { ScrollView } from "react-native";
+
 import styled from "styled-components/native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import Loading from "@/src/components/ui/Loading";
 import CommonError from "@/src/components/ui/CommonError";
-import CachedImage from "@/src/components/ui/CachedImage";
-import { shadowProps } from "@/src/constants/shadowProps";
-import { theme } from "@/src/constants/theme";
-import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
+import ChatHeader from "../components/ChatHeader";
 import AiChatBox from "../components/AiChatBox";
 import UserChatBox from "../components/UserChatBox";
+import ChatInput from "../components/ChatInput";
 import { useChatting } from "../hooks/useChatting";
 import type { TThreadDate } from "../types/chattingTypes";
-import ChatHeader from "../components/ChatHeader";
+import { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 
 type ChattingContainerProps = {
   threadDate: TThreadDate;
@@ -80,24 +78,9 @@ export default function ChattingContainer({
             )
           )}
         </ScrollBox>
-        <KeyboardAvoidingBox behavior={Platform.OS === "ios" ? "padding" : "height"}>
-          {!readonly && (
-            <ChatInputBox>
-              <ChatInput
-                placeholder="오늘 하루에 대해 말해주세요"
-                multiline={true}
-                value={input}
-                onChangeText={(e) => setInput(e)}
-                hitSlop={15}
-                placeholderTextColor={theme.colors.placeholderText}
-              />
-              <ChatButton hitSlop={15} style={shadowProps} onPress={handleSubmitPress}>
-                <ButtonImage source={require("@/assets/images/chatButton.png")} />
-              </ChatButton>
-            </ChatInputBox>
-          )}
-        </KeyboardAvoidingBox>
+        <ChatInput input={input} setInput={setInput} onSubmitPress={handleSubmitPress} readonly={readonly} />
       </SafeView>
+      <InfoText>뒤로 가기 버튼을 누르면 대화가 자동으로 요약됩니다</InfoText>
     </Fragment>
   );
 }
@@ -112,44 +95,10 @@ const ScrollBox = styled(ScrollView)`
   background-color: ${({ theme }) => theme.colors.whiteBlue};
 `;
 
-const KeyboardAvoidingBox = styled.KeyboardAvoidingView`
-  width: 100%;
-  justify-content: center;
-  align-items: center;
-`;
-
-const ChatInputBox = styled.View`
-  width: 100%;
-  min-height: ${responsiveToPx("100px")};
-  background-color: ${({ theme }) => theme.colors.whiteBlue};
-  flex-direction: row;
-  justify-content: center;
-  align-items: flex-end;
-  gap: ${({ theme }) => theme.gap.md};
-  padding-bottom: ${responsiveToPx("40px")};
-`;
-
-const ChatInput = styled.TextInput`
-  width: ${responsiveToPx("333px")};
-  max-height: ${responsiveToPx("100px")};
-  padding: ${responsiveToPx("11px")} ${responsiveToPx("16px")};
-  background-color: ${({ theme }) => theme.colors.white};
-  border: 1px solid ${({ theme }) => theme.colors.gray};
-  border-radius: ${({ theme }) => theme.borderRadius.sm};
+const InfoText = styled.Text`
+  text-align: center;
+  bottom: ${responsiveToPxByHeight("30px")};
+  color: ${({ theme }) => theme.colors.assistantChat};
   font-family: ${({ theme }) => theme.fontFamily.nsRegular};
-  font-size: ${({ theme }) => theme.fontSize.base};
-`;
-
-const ChatButton = styled.TouchableOpacity`
-  width: ${responsiveToPx("44px")};
-  height: ${responsiveToPx("44px")};
-  border-radius: 9999px;
-  justify-content: center;
-  align-items: center;
-  overflow: hidden;
-`;
-
-const ButtonImage = styled(Img)`
-  width: 120%;
-  height: 120%;
+  font-size: ${({ theme }) => theme.fontSize.xs};
 `;

--- a/src/features/chatting/hooks/useIsKeyboardOpen.ts
+++ b/src/features/chatting/hooks/useIsKeyboardOpen.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { Keyboard, Platform } from "react-native";
+
+export const useIsKeyboardOpen = () => {
+  const [isKeyboardOpen, setIsKeyboardOpen] = useState<boolean>(false);
+
+  const handleKeyboardShow = () => setIsKeyboardOpen(true);
+  const handleKeyboardHide = () => setIsKeyboardOpen(false);
+
+  useEffect(() => {
+    const showEventType = Platform.OS === "android" ? "keyboardDidShow" : "keyboardWillShow";
+    const hideEventType = Platform.OS === "android" ? "keyboardDidHide" : "keyboardWillHide";
+    const didShowEvent = Keyboard.addListener(showEventType, handleKeyboardShow);
+    const didHideEvent = Keyboard.addListener(hideEventType, handleKeyboardHide);
+
+    return () => {
+      didShowEvent.remove();
+      didHideEvent.remove();
+    };
+  }, []);
+
+  return isKeyboardOpen;
+};


### PR DESCRIPTION
## 👀 관련 이슈

close #48 

## ✨ 작업한 내용

- [X] 채팅 페이지에서 키보드가 내려가 있을 때는 안내 텍스트가 보이고, 키보드가 올라오면 안내 텍스트가 사라지도록 구현
- [X] 채팅 페이지의 인풋 컴포넌트 레이아웃을 더 보기 편하게 개선 (기존에는 과한 padding으로 인해 보기 좋지 않았음)

[Expo docs](https://docs.expo.dev/guides/keyboard-handling/)

## 📷스크린샷 / 영상

https://github.com/user-attachments/assets/99297bef-115c-4325-869f-379ebe851422