### PR TITLE
[dev <- hotfix] 설정 데이터를 가져오는 useQuery 2개의 queryFn 반환 타입 통일

### DIFF
--- a/src/features/chatting/hooks/queries/useSleepTimeQuery.ts
+++ b/src/features/chatting/hooks/queries/useSleepTimeQuery.ts
@@ -13,7 +13,7 @@ type UserSettingDTO = SuccessDTO & {
 
 const _getUserSetting = async () => {
   const { data } = await axiosInstance.get<UserSettingDTO>(endpoint.setting.setting);
-  return data.result;
+  return data;
 };
 
 /**
@@ -24,6 +24,6 @@ export const useSleepTimeQuery = () => {
     queryFn: _getUserSetting,
     queryKey: ["user-setting"],
     staleTime: 5 * 60 * 1000,
-    select: (data) => data.sleepTime,
+    select: (data) => data.result.sleepTime,
   });
 };


### PR DESCRIPTION
## 👀 관련 이슈

close #51 

두 query 훅에서 사용하는 queryFn의 반환 타입이 달라, A로 fetch하면 B가 실행될 때 터지고, B로 fetch하면 A가 실행될 때 터지는 상황이었다.

## ✨ 작업한 내용

- [x] `useSleepTimeQuery`와 `useSettingQuery`에서 사용하는 `queryFn`의 반환 타입 통일