### PR TITLE
[dev <- hotfix] aiProfileId를 백엔드에서 관리하도록 위임

### DIFF
--- a/src/app/(app)/chatting.tsx
+++ b/src/app/(app)/chatting.tsx
@@ -1,16 +1,14 @@
-import { useState } from "react";
 import styled from "styled-components/native";
 import CommonError from "@/src/components/ui/CommonError";
 import Loading from "@/src/components/ui/Loading";
-import { setAiProfileId } from "@/src/libs/mmkv";
 import ChattingContainer from "@/src/features/chatting/containers/ChattingContainer";
 import AssistantListContainer from "@/src/features/assistantList/containers/AssistantListContainer";
 import { useInitializeChatting } from "@/src/features/chatting/hooks/useInitializeChatting";
 import { readOnlyTypeGuard } from "@/src/features/chatting/utils/readOnlyTypeGuard";
 
 export default function ChattingRouter(): JSX.Element | null {
-  const [isVisible, setIsVisible] = useState<boolean>(false);
-  const { isPending, isError, readOnlyDate, threadDate, threadExpiredDate, handleRetry } = useInitializeChatting();
+  const { isPending, isError, aiProfileId, readOnlyDate, threadDate, threadExpiredDate, handleRetry } =
+    useInitializeChatting();
 
   if (isPending) {
     return <Loading />;
@@ -37,15 +35,7 @@ export default function ChattingRouter(): JSX.Element | null {
   if (!threadDate || !threadExpiredDate) {
     return (
       <FlexView>
-        <AssistantListContainer
-          isVisible={isVisible}
-          setIsVisible={setIsVisible}
-          onPressAiCard={(aiProfileId) => {
-            setAiProfileId(aiProfileId);
-            handleRetry();
-          }}
-        />
-        <CommonError titleText="서포터를 선택해주세요" buttonText="선택하기" onPress={() => setIsVisible(true)} />
+        <CommonError titleText="문제가 발생했어요." buttonText="다시 시도" onPress={handleRetry} />
       </FlexView>
     );
   }

--- a/src/app/(app)/chatting.tsx
+++ b/src/app/(app)/chatting.tsx
@@ -7,7 +7,8 @@ import { useInitializeChatting } from "@/src/features/chatting/hooks/useInitiali
 import { readOnlyTypeGuard } from "@/src/features/chatting/utils/readOnlyTypeGuard";
 
 export default function ChattingRouter(): JSX.Element | null {
-  const { isPending, isError, readOnlyDate, threadDate, threadExpiredDate, handleRetry } = useInitializeChatting();
+  const { aiProfileId, isPending, isError, readOnlyDate, threadDate, threadExpiredDate, handleRetry } =
+    useInitializeChatting();
 
   if (isPending) {
     return <Loading />;
@@ -35,7 +36,12 @@ export default function ChattingRouter(): JSX.Element | null {
       threadDate={threadDate}
       threadExpiredDate={threadExpiredDate}
       renderAssistantList={({ isVisible, setIsVisible, onPressAiCard }) => (
-        <AssistantListContainer isVisible={isVisible} setIsVisible={setIsVisible} onPressAiCard={onPressAiCard} />
+        <AssistantListContainer
+          aiProfileId={aiProfileId}
+          isVisible={isVisible}
+          setIsVisible={setIsVisible}
+          onPressAiCard={onPressAiCard}
+        />
       )}
     />
   );

--- a/src/app/(app)/chatting.tsx
+++ b/src/app/(app)/chatting.tsx
@@ -7,8 +7,7 @@ import { useInitializeChatting } from "@/src/features/chatting/hooks/useInitiali
 import { readOnlyTypeGuard } from "@/src/features/chatting/utils/readOnlyTypeGuard";
 
 export default function ChattingRouter(): JSX.Element | null {
-  const { isPending, isError, aiProfileId, readOnlyDate, threadDate, threadExpiredDate, handleRetry } =
-    useInitializeChatting();
+  const { isPending, isError, readOnlyDate, threadDate, threadExpiredDate, handleRetry } = useInitializeChatting();
 
   if (isPending) {
     return <Loading />;
@@ -20,16 +19,7 @@ export default function ChattingRouter(): JSX.Element | null {
 
   // readonly 채팅방이 필요한 경우
   if (readOnlyTypeGuard(readOnlyDate)) {
-    return (
-      <ChattingContainer
-        threadDate={readOnlyDate}
-        threadExpiredDate={new Date()}
-        readonly={true}
-        renderAssistantList={({ isVisible, setIsVisible, onPressAiCard }) => (
-          <AssistantListContainer isVisible={isVisible} setIsVisible={setIsVisible} onPressAiCard={onPressAiCard} />
-        )}
-      />
-    );
+    return <ChattingContainer threadDate={readOnlyDate} threadExpiredDate={new Date()} readonly />;
   }
 
   if (!threadDate || !threadExpiredDate) {

--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -7,7 +7,10 @@ const endpoint = {
     delete: "/api/v1/user",
     refresh: "/api/v1/auth/refresh",
   },
-  aiProfile: "/api/v1/ai-profiles",
+  aiProfile: {
+    aiProfile: "/api/v1/ai-profiles",
+    recent: "/api/v1/ai-profiles/recent",
+  },
   setting: {
     checkNew: "/api/v1/user-settings/check-new",
     register: "/api/v1/user-settings/register",

--- a/src/features/assistantList/containers/AssistantListContainer.tsx
+++ b/src/features/assistantList/containers/AssistantListContainer.tsx
@@ -8,12 +8,14 @@ import { useAssistantListQuery } from "../hooks/queries/useAssistantListQuery";
 import AssistantCard from "../components/AssistantCard";
 
 type AssistantListContainerProps = {
+  aiProfileId?: number;
   isVisible: boolean;
   setIsVisible: Dispatch<SetStateAction<boolean>>;
   onPressAiCard: (aiProfileId: number) => void;
 };
 
 export default function AssistantListContainer({
+  aiProfileId,
   isVisible,
   setIsVisible,
   onPressAiCard,
@@ -23,6 +25,14 @@ export default function AssistantListContainer({
 
   const handleOuterClick = () => {
     setIsVisible(false);
+  };
+
+  const getDefaultIdx = () => {
+    let idx = 0;
+    if (aiProfileId && data) {
+      idx = data.findIndex((e) => "aiProfileId" in e && e.aiProfileId === aiProfileId);
+    }
+    return Math.max(idx, 0);
   };
 
   if (isVisible) {
@@ -73,6 +83,7 @@ export default function AssistantListContainer({
               <AssistantCard item={item} onPressAiCard={onPressAiCard} />
             </ItemLayout>
           )}
+          defaultIndex={getDefaultIdx()}
         />
       </AssistantListLayout>
     );

--- a/src/features/assistantList/hooks/mutations/useRemoveAssistantMutation.ts
+++ b/src/features/assistantList/hooks/mutations/useRemoveAssistantMutation.ts
@@ -6,7 +6,7 @@ import endpoint from "@/src/constants/endpoint";
 import type { SuccessDTO } from "@/src/types/commonTypes";
 
 const _removeAssistant = async (aiProfileId: number) => {
-  const { data } = await axiosInstance.delete<SuccessDTO>(endpoint.aiProfile, { params: { aiProfileId } });
+  const { data } = await axiosInstance.delete<SuccessDTO>(endpoint.aiProfile.aiProfile, { params: { aiProfileId } });
   return data;
 };
 

--- a/src/features/assistantList/hooks/queries/useAssistantListQuery.ts
+++ b/src/features/assistantList/hooks/queries/useAssistantListQuery.ts
@@ -4,7 +4,7 @@ import endpoint from "@/src/constants/endpoint";
 import type { AssistantProfileListDTO, TAssistantProfile, TNewAiTrigger } from "../../types/assistantListTypes";
 
 export const _assistantListWithNewAiTrigger = async () => {
-  const { data } = await axiosInstance.get<AssistantProfileListDTO>(endpoint.aiProfile);
+  const { data } = await axiosInstance.get<AssistantProfileListDTO>(endpoint.aiProfile.aiProfile);
   const dataWithNewAiTrigger: (TAssistantProfile | TNewAiTrigger)[] = [...data.result, { isGenerateButton: true }];
   return dataWithNewAiTrigger;
 };

--- a/src/features/chatting/containers/ChattingContainer.tsx
+++ b/src/features/chatting/containers/ChattingContainer.tsx
@@ -11,23 +11,24 @@ import ChatInput from "../components/ChatInput";
 import { useChatting } from "../hooks/useChatting";
 import type { TThreadDate } from "../types/chattingTypes";
 
-type ChattingContainerProps = {
-  threadDate: TThreadDate;
-  threadExpiredDate: Date;
-  readonly?: boolean;
-  renderAssistantList: (props: {
-    isVisible: boolean;
-    setIsVisible: Dispatch<SetStateAction<boolean>>;
-    onPressAiCard: (id: number) => void;
-  }) => ReactNode;
-};
+type ChattingContainerProps =
+  | {
+      threadDate: TThreadDate;
+      threadExpiredDate: Date;
+      readonly?: false;
+      renderAssistantList: (props: {
+        isVisible: boolean;
+        setIsVisible: Dispatch<SetStateAction<boolean>>;
+        onPressAiCard: (id: number) => void;
+      }) => ReactNode;
+    }
+  | {
+      threadDate: TThreadDate;
+      threadExpiredDate: Date;
+      readonly: true;
+    };
 
-export default function ChattingContainer({
-  threadDate,
-  threadExpiredDate,
-  renderAssistantList,
-  readonly,
-}: ChattingContainerProps) {
+export default function ChattingContainer(props: ChattingContainerProps) {
   const scrollViewRef = useRef<ScrollView>(null);
 
   const {
@@ -42,7 +43,7 @@ export default function ChattingContainer({
     handlePressAiCard,
     handleHeaderPress,
     handleSubmitPress,
-  } = useChatting(threadDate, threadExpiredDate, readonly);
+  } = useChatting(props.threadDate, props.threadExpiredDate, props.readonly);
 
   if (isPending) {
     return <Loading />;
@@ -54,13 +55,13 @@ export default function ChattingContainer({
 
   return (
     <Fragment>
-      {renderAssistantList({ isVisible, setIsVisible, onPressAiCard: handlePressAiCard })}
+      {!props.readonly && props.renderAssistantList({ isVisible, setIsVisible, onPressAiCard: handlePressAiCard })}
       <SafeView edges={["left", "right", "top"]}>
         <ChatHeader
           imageSrc={data.result.aiProfileImageS3}
           assistantName={data.result.aiProfileName}
           onPress={handleHeaderPress}
-          readonly={readonly}
+          readonly={props.readonly}
         />
         <ScrollBox
           ref={scrollViewRef}
@@ -76,7 +77,7 @@ export default function ChattingContainer({
             )
           )}
         </ScrollBox>
-        <ChatInput input={input} setInput={setInput} onSubmitPress={handleSubmitPress} readonly={readonly} />
+        <ChatInput input={input} setInput={setInput} onSubmitPress={handleSubmitPress} readonly={props.readonly} />
       </SafeView>
     </Fragment>
   );

--- a/src/features/chatting/hooks/mutations/useChangeAssistantMutation.ts
+++ b/src/features/chatting/hooks/mutations/useChangeAssistantMutation.ts
@@ -23,8 +23,9 @@ export const useChangeAssistantMutation = (setIsVisible: Dispatch<SetStateAction
 
   return useMutation({
     mutationFn: _changeAssistant,
-    onSuccess: (data, { year, month, day }) => {
+    onSuccess: (_, { year, month, day }) => {
       queryClient.invalidateQueries({ queryKey: ["messages", year, month, day] });
+      queryClient.refetchQueries({ queryKey: ["aiProfileId"] });
       showToast(toastMessage.changeAssistant.success, "success");
       setIsVisible(false);
     },

--- a/src/features/chatting/hooks/mutations/useChangeAssistantMutation.ts
+++ b/src/features/chatting/hooks/mutations/useChangeAssistantMutation.ts
@@ -25,7 +25,7 @@ export const useChangeAssistantMutation = (setIsVisible: Dispatch<SetStateAction
     mutationFn: _changeAssistant,
     onSuccess: (_, { year, month, day }) => {
       queryClient.invalidateQueries({ queryKey: ["messages", year, month, day] });
-      queryClient.refetchQueries({ queryKey: ["aiProfileId"] });
+      queryClient.invalidateQueries({ queryKey: ["aiProfileId"] });
       showToast(toastMessage.changeAssistant.success, "success");
       setIsVisible(false);
     },

--- a/src/features/chatting/hooks/queries/useAiProfileIdQuery.ts
+++ b/src/features/chatting/hooks/queries/useAiProfileIdQuery.ts
@@ -1,0 +1,22 @@
+import endpoint from "@/src/constants/endpoint";
+import axiosInstance from "@/src/libs/axiosInstance";
+import { SuccessDTO } from "@/src/types/commonTypes";
+import { useQuery } from "@tanstack/react-query";
+
+type AiProfileIdDTO = SuccessDTO & {
+  result: {
+    aiProfileId: number;
+  };
+};
+
+const _getAiProfileId = async () => {
+  const { data } = await axiosInstance<AiProfileIdDTO>(endpoint.aiProfile.recent);
+  return data.result.aiProfileId;
+};
+
+export const useAiProfileIdQuery = () => {
+  return useQuery({
+    queryFn: _getAiProfileId,
+    queryKey: ["aiProfileId"],
+  });
+};

--- a/src/features/chatting/hooks/useChatting.ts
+++ b/src/features/chatting/hooks/useChatting.ts
@@ -2,7 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useRouter } from "expo-router";
 import EventSource from "react-native-sse";
-import { getAccessToken, setAiProfileId } from "@/src/libs/mmkv";
+import { getAccessToken } from "@/src/libs/mmkv";
 import { preventDoublePress } from "@/src/libs/esToolkit";
 import showToast from "@/src/libs/showToast";
 import toastMessage from "@/src/constants/toastMessage";
@@ -31,7 +31,6 @@ export const useChatting = (threadDate: TThreadDate, threadExpiredDate: Date, re
   };
 
   const handlePressAiCard = (aiProfileId: number) => {
-    setAiProfileId(aiProfileId);
     changeAssistantMutate({ ...threadDate, aiProfileId });
   };
 

--- a/src/features/chatting/hooks/useInitializeChatting.ts
+++ b/src/features/chatting/hooks/useInitializeChatting.ts
@@ -58,5 +58,5 @@ export const useInitializeChatting = () => {
     }
   }, [aiProfileId, handleMakeThreadMutate, isFirstEffect, sleepTime]);
 
-  return { isPending, isError, readOnlyDate, threadDate, threadExpiredDate, handleRetry };
+  return { aiProfileId, isPending, isError, readOnlyDate, threadDate, threadExpiredDate, handleRetry };
 };

--- a/src/features/chatting/hooks/useInitializeChatting.ts
+++ b/src/features/chatting/hooks/useInitializeChatting.ts
@@ -7,6 +7,7 @@ import { getThreadDateExpired } from "../utils/time";
 import type { TThreadDate, TThreadDateSearchParams } from "../types/chattingTypes";
 
 export const useInitializeChatting = () => {
+  const [isFirstEffect, setIsFirstEffect] = useState<boolean>(true);
   const { year, month, day } = useLocalSearchParams() as unknown as TThreadDateSearchParams;
   const [threadDate, setThreadDate] = useState<TThreadDate | null>(null);
   const [threadExpiredDate, setThreadExpiredDate] = useState<Date | null>(null);
@@ -51,8 +52,11 @@ export const useInitializeChatting = () => {
   };
 
   useEffect(() => {
-    if (sleepTime && aiProfileId) handleMakeThreadMutate(sleepTime, aiProfileId);
-  }, [aiProfileId, handleMakeThreadMutate, sleepTime]);
+    if (isFirstEffect && sleepTime && aiProfileId) {
+      handleMakeThreadMutate(sleepTime, aiProfileId);
+      setIsFirstEffect(false);
+    }
+  }, [aiProfileId, handleMakeThreadMutate, isFirstEffect, sleepTime]);
 
   return { isPending, isError, aiProfileId, readOnlyDate, threadDate, threadExpiredDate, handleRetry };
 };

--- a/src/features/chatting/hooks/useInitializeChatting.ts
+++ b/src/features/chatting/hooks/useInitializeChatting.ts
@@ -1,27 +1,37 @@
 import { useLocalSearchParams } from "expo-router";
-import { TThreadDate, type TThreadDateSearchParams } from "../types/chattingTypes";
 import { useCallback, useEffect, useState } from "react";
 import { useSleepTimeQuery } from "./queries/useSleepTimeQuery";
+import { useAiProfileIdQuery } from "./queries/useAiProfileIdQuery";
 import { useMakeThreadMutation } from "./mutations/useMakeThreadMutation";
-import { getAiProfileId } from "@/src/libs/mmkv";
 import { getThreadDateExpired } from "../utils/time";
+import type { TThreadDate, TThreadDateSearchParams } from "../types/chattingTypes";
 
 export const useInitializeChatting = () => {
   const { year, month, day } = useLocalSearchParams() as unknown as TThreadDateSearchParams;
   const [threadDate, setThreadDate] = useState<TThreadDate | null>(null);
   const [threadExpiredDate, setThreadExpiredDate] = useState<Date | null>(null);
 
-  const { isPending: isSleepTimePending, isError: isSleepTimeError, data: sleepTime, refetch } = useSleepTimeQuery();
+  const {
+    isPending: isAiProfileIdPending,
+    isError: isAiProfileIdError,
+    data: aiProfileId,
+    refetch: refetchAiProfileId,
+  } = useAiProfileIdQuery();
+  const {
+    isPending: isSleepTimePending,
+    isError: isSleepTimeError,
+    data: sleepTime,
+    refetch: refetchSleepTime,
+  } = useSleepTimeQuery();
   const { isPending: isMutatePending, isError: isMutateError, mutate } = useMakeThreadMutation();
 
-  const isPending = isSleepTimePending || isMutatePending;
-  const isError = isSleepTimeError || isMutateError;
+  const isPending = isSleepTimePending || isAiProfileIdPending || isMutatePending;
+  const isError = isSleepTimeError || isAiProfileIdError || isMutateError;
   const readOnlyDate = { year, month, day };
 
   const handleMakeThreadMutate = useCallback(
-    (sleepTime: string) => {
+    (sleepTime: string, aiProfileId: number) => {
       if (year || month || day) return;
-      const aiProfileId = getAiProfileId();
       if (aiProfileId) {
         const sleepHour = parseInt(sleepTime.slice(0, 2));
         const [{ year, month, day }, expiredDate] = getThreadDateExpired(sleepHour);
@@ -30,19 +40,19 @@ export const useInitializeChatting = () => {
         mutate({ aiProfileId, year, month, day });
       }
     },
-    [day, month, year, mutate]
+    [year, month, day, mutate]
   );
 
   const handleRetry = async () => {
-    await refetch();
-    if (sleepTime) {
-      handleMakeThreadMutate(sleepTime);
+    await Promise.all([refetchAiProfileId(), refetchSleepTime()]);
+    if (sleepTime && aiProfileId) {
+      handleMakeThreadMutate(sleepTime, aiProfileId);
     }
   };
 
   useEffect(() => {
-    if (sleepTime) handleMakeThreadMutate(sleepTime);
-  }, [handleMakeThreadMutate, sleepTime]);
+    if (sleepTime && aiProfileId) handleMakeThreadMutate(sleepTime, aiProfileId);
+  }, [aiProfileId, handleMakeThreadMutate, sleepTime]);
 
-  return { isPending, isError, readOnlyDate, threadDate, threadExpiredDate, handleRetry };
+  return { isPending, isError, aiProfileId, readOnlyDate, threadDate, threadExpiredDate, handleRetry };
 };

--- a/src/features/chatting/hooks/useInitializeChatting.ts
+++ b/src/features/chatting/hooks/useInitializeChatting.ts
@@ -58,5 +58,5 @@ export const useInitializeChatting = () => {
     }
   }, [aiProfileId, handleMakeThreadMutate, isFirstEffect, sleepTime]);
 
-  return { isPending, isError, aiProfileId, readOnlyDate, threadDate, threadExpiredDate, handleRetry };
+  return { isPending, isError, readOnlyDate, threadDate, threadExpiredDate, handleRetry };
 };

--- a/src/features/makeAssistant/apis/makeAssistantApi.ts
+++ b/src/features/makeAssistant/apis/makeAssistantApi.ts
@@ -3,6 +3,6 @@ import endpoint from "@/src/constants/endpoint";
 import type { MakeAssistantDTO, TAssistantMakeQnA } from "../types/makeAssistantTypes";
 
 export const _makeAssistant = async (answers: TAssistantMakeQnA) => {
-  const { data } = await axiosInstance.post<MakeAssistantDTO>(endpoint.aiProfile, answers);
+  const { data } = await axiosInstance.post<MakeAssistantDTO>(endpoint.aiProfile.aiProfile, answers);
   return data;
 };

--- a/src/features/makeAssistant/hooks/mutations/useMakeAssistantMutation.ts
+++ b/src/features/makeAssistant/hooks/mutations/useMakeAssistantMutation.ts
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { useRouter } from "expo-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useIsNewUserContext } from "@/src/contexts/isNewUserProvider";
-import { setAiProfileId } from "@/src/libs/mmkv";
 import { _makeAssistant } from "../../apis/makeAssistantApi";
 import type { MakeAssistantDTO, TAssistantMakeQnA } from "../../types/makeAssistantTypes";
 
@@ -27,14 +26,13 @@ export const useMakeAssistantMutation = ({ answers }: TProps) => {
   const handleSuccess = (data: MakeAssistantDTO) => {
     console.log(data.message);
     if (isNewUser) {
-      console.log("새로운 유저입니다. mmkv에 생성된 어시스턴트 id를 저장합니다...");
-      setAiProfileId(data.result.aiProfileId);
+      console.log("새로운 유저입니다.");
       setTimeout(() => {
         console.log("/main으로 리다이렉트합니다.");
         router.replace("/(app)/main");
       }, 2500);
     } else {
-      console.log("기존 유저입니다. mmkv를 그대로 둡니다...");
+      console.log("기존 유저입니다.");
       queryClient.invalidateQueries({ queryKey: ["assistant-list"] });
       setTimeout(() => {
         console.log("이전 페이지로 back 합니다.");

--- a/src/features/makeAssistant/hooks/queries/useMakeAssistantQuestionQuery.ts
+++ b/src/features/makeAssistant/hooks/queries/useMakeAssistantQuestionQuery.ts
@@ -4,7 +4,9 @@ import type { MakeAssistantQuestionDTO } from "../../types/makeAssistantTypes";
 import { useQuery } from "@tanstack/react-query";
 
 const _getAssistantQuestion = async (aiProfileId: string) => {
-  const { data } = await axiosInstance.get<MakeAssistantQuestionDTO>(`${endpoint.aiProfile}/${aiProfileId}/question`);
+  const { data } = await axiosInstance.get<MakeAssistantQuestionDTO>(
+    `${endpoint.aiProfile.aiProfile}/${aiProfileId}/question`
+  );
   return data;
 };
 

--- a/src/features/setting/hooks/mutations/useDeleteAccountMutation.ts
+++ b/src/features/setting/hooks/mutations/useDeleteAccountMutation.ts
@@ -1,6 +1,6 @@
 import { router } from "expo-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { removeAccessToken, removeAiProfileId } from "@/src/libs/mmkv";
+import { removeAccessToken } from "@/src/libs/mmkv";
 import { removeRefreshToken } from "@/src/libs/secureStorage";
 import showToast from "@/src/libs/showToast";
 import axiosInstance from "@/src/libs/axiosInstance";
@@ -23,7 +23,6 @@ export const useDeleteAccountMutation = () => {
       console.log(data);
       await removeRefreshToken();
       removeAccessToken();
-      removeAiProfileId();
       queryClient.clear();
       router.replace("/login");
     },

--- a/src/features/setting/hooks/mutations/useLogoutMutation.ts
+++ b/src/features/setting/hooks/mutations/useLogoutMutation.ts
@@ -1,7 +1,7 @@
 import { router } from "expo-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { removeRefreshToken } from "@/src/libs/secureStorage";
-import { removeAccessToken, removeAiProfileId } from "@/src/libs/mmkv";
+import { removeAccessToken } from "@/src/libs/mmkv";
 import showToast from "@/src/libs/showToast";
 import axiosInstance from "@/src/libs/axiosInstance";
 import toastMessage from "@/src/constants/toastMessage";
@@ -23,7 +23,6 @@ export const useLogoutMutation = () => {
       console.log(data);
       await removeRefreshToken();
       removeAccessToken();
-      removeAiProfileId();
       queryClient.clear();
       router.replace("/login");
     },

--- a/src/libs/mmkv.ts
+++ b/src/libs/mmkv.ts
@@ -10,19 +10,6 @@ const removeStorageValue = (key: string): void => {
   storage.delete(key);
 };
 
-export const getAiProfileId = (): number | null => {
-  const aiProfileId = storage.getNumber("aiProfileId");
-  return aiProfileId ? aiProfileId : null;
-};
-
-export const setAiProfileId = (aiProfileId: number): void => {
-  storage.set("aiProfileId", aiProfileId);
-};
-
-export const removeAiProfileId = (): void => {
-  removeStorageValue("aiProfileId");
-};
-
 export const getAccessToken = (): string | null => {
   const accessToken = storage.getString("accessToken");
   return accessToken ? accessToken : null;

--- a/src/libs/queryClient.ts
+++ b/src/libs/queryClient.ts
@@ -2,7 +2,7 @@ import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 import { router } from "expo-router";
 import showToast from "@/src/libs/showToast";
 import { removeRefreshToken } from "@/src/libs/secureStorage";
-import { removeAccessToken, removeAiProfileId } from "@/src/libs/mmkv";
+import { removeAccessToken } from "@/src/libs/mmkv";
 import toastMessage from "@/src/constants/toastMessage";
 
 export default new QueryClient({
@@ -22,7 +22,6 @@ export default new QueryClient({
           // 다른 기기에서 이미 삭제된 계정인 경우
           await removeRefreshToken();
           removeAccessToken();
-          removeAiProfileId();
           showToast(toastMessage.accountNotFound, "error");
           router.navigate("/login");
         } else if (code !== "401") {
@@ -40,7 +39,6 @@ export default new QueryClient({
           // 다른 기기에서 이미 삭제된 계정인 경우
           await removeRefreshToken();
           removeAccessToken();
-          removeAiProfileId();
           showToast(toastMessage.accountNotFound, "error");
           router.navigate("/login");
         }


### PR DESCRIPTION
## 👀 관련 이슈

close #34 

## ✨ 작업한 내용

- [x] `useAiProfileIdQuery` 훅 구현
- [x] 스레드 생성 or 가져오는 비즈니스 로직에서 사용하는 `aiProfileId` 값을 `useAiProfileIdQuery`로 가져오도록 변경
- [x] 로컬 스토리지 (mmkv)를 활용하던 부분 (getAiProfileId, setAiProfileId, removeAiProfileId) 제거 및 tanstack-query로 관리하도록 수정
- [x] ai 프로필 캐러셀 시작 지점을 aiProfileId 값으로 설정
- [x] 기타 작업(컴포넌트 유니온 타입 고도화, useEffect를 한 번만 실행되도록 해 불필요한 깜빡임 제거)

## 📷스크린샷 / 영상

> 거의 모든 엣지 케이스 신경 쓰면서 구현하긴 했습니다..!

https://github.com/user-attachments/assets/d8958052-d951-405d-a9f7-c4256294de05