### PR TITLE
[dev] 채팅 streaming 시 띄어쓰기가 되지 않는 문제 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-native-reanimated-carousel": "canary",
     "react-native-safe-area-context": "5.1.0",
     "react-native-screens": "~4.8.0",
-    "react-native-sse": "^1.2.1",
+    "react-native-sse": "1.2.1",
     "react-native-toast-message": "^2.2.1",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.13.5",
@@ -78,7 +78,8 @@
   "private": true,
   "pnpm": {
     "patchedDependencies": {
-      "react-native-calendars@1.1308.1": "patches/react-native-calendars@1.1308.1.patch"
+      "react-native-calendars@1.1308.1": "patches/react-native-calendars@1.1308.1.patch",
+      "react-native-sse@1.2.1": "patches/react-native-sse@1.2.1.patch"
     }
   }
 }

--- a/patches/react-native-sse@1.2.1.patch
+++ b/patches/react-native-sse@1.2.1.patch
@@ -1,0 +1,13 @@
+diff --git a/src/EventSource.js b/src/EventSource.js
+index 6a7b146ef5872f72eda3eb52c265abb996fd7014..e43fcf8a32a310166f1a7d2e18b2050a92c7a49f 100644
+--- a/src/EventSource.js
++++ b/src/EventSource.js
+@@ -214,7 +214,7 @@ class EventSource {
+           this.interval = retry;
+         }
+       } else if (line.startsWith('data')) {
+-        data.push(line.replace(/data:?\s*/, ''));
++        data.push(line.replace(/^data:/, ''));
+       } else if (line.startsWith('id')) {
+         id = line.replace(/id:?\s*/, '');
+         if (id !== '') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   react-native-calendars@1.1308.1:
     hash: nnurlqmg6jwybeqtzhjefpcclu
     path: patches/react-native-calendars@1.1308.1.patch
+  react-native-sse@1.2.1:
+    hash: 4vnnvvussd2kkzulmcakuihcsu
+    path: patches/react-native-sse@1.2.1.patch
 
 importers:
 
@@ -137,8 +140,8 @@ importers:
         specifier: ~4.8.0
         version: 4.8.0(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.3.20)(react@18.3.1))(react@18.3.1)
       react-native-sse:
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: 1.2.1
+        version: 1.2.1(patch_hash=4vnnvvussd2kkzulmcakuihcsu)
       react-native-toast-message:
         specifier: ^2.2.1
         version: 2.2.1(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.3.20)(react@18.3.1))(react@18.3.1)
@@ -11214,7 +11217,7 @@ snapshots:
       react-native: 0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.3.20)(react@18.3.1)
       warn-once: 0.1.1
 
-  react-native-sse@1.2.1: {}
+  react-native-sse@1.2.1(patch_hash=4vnnvvussd2kkzulmcakuihcsu): {}
 
   react-native-swipe-gestures@1.0.5: {}
 


### PR DESCRIPTION
## 👀 관련 이슈

close #35

## ❓ 문제 파악

curl을 사용해 백엔드로 직접 요청을 찔렀을 때는 띄어쓰기가 포함되어 날아왔으나, RN 환경에서 요청을 찌르면 띄어쓰기가 사라지는 것을 발견했다. 

RN에서 채팅 SSE를 수신하기 위한 라이브러리로 [react-native-sse](https://www.npmjs.com/package/react-native-sse)를 사용 중이었기 때문에 해당 라이브러리 코드를 살펴보았다.

```js
// node_modules/react-native-sse/src/EventSource.js

...
_handleEvent(response) {
  ...
  let type = undefined;
  let id = null;
  let data = [];
  let retry = 0;
  let line = '';

  for (let i = 0; i < parts.length; i++) {
    line = parts[i].trim();
    if (line.startsWith('event')) {
      type = line.replace(/event:?\s*/, '');
    } else if (line.startsWith('retry')) {
      retry = parseInt(line.replace(/retry:?\s*/, ''), 10);
      if (!isNaN(retry)) {
        this.interval = retry;
      }
    } else if (line.startsWith('data')) {
      data.push(line.replace(/data:?\s*/, ''));
    } else if (line.startsWith('id')) {
      id = line.replace(/id:?\s*/, '');
      if (id !== '') {
        this.lastEventId = id;
      } else {
        this.lastEventId = null;
      }
    } else if (line === '') {
      if (data.length > 0) {
        const eventType = type || 'message';
        const event = {
          type: eventType,
          data: data.join('\n'),
          url: this.url,
          lastEventId: this.lastEventId,
        };

        this.dispatch(eventType, event);

        data = [];
        type = undefined;
      }
    }
  }
}
```

정규식을 사용해 공백을 제거하는 로직들이 포함되어 있었고, 메시지 데이터가 담겨있는 `event.data`에 대해서도 적용되고 있다는 것을 확인했다.

```js
// node_modules/react-native-sse/src/EventSource.js

else if (line.startsWith('data')) {
  data.push(line.replace(/data:?\s*/, '')); // "   안녕" 을 "안녕"으로 변경한다 😢 
}
```

해당 정규식을 수정하니 띄어쓰기가 정상적으로 되는 것을 확인할 수 있다.

```js
// node_modules/react-native-sse/src/EventSource.js

else if (line.startsWith('data')) {
  data.push(line.replace(/^data:/, '')); // "   안녕" 을 "   안녕" 그대로 반환한다 😄 
}
```

> RN 환경에서의 이벤트 스트리밍 log, 띄어쓰기 데이터가 잘 포함된 것을 알 수 있다.

```json
{"data": "", "lastEventId": "1743910476224", "type": "aiMessage"}
{"data": "응", "lastEventId": "1743910476224", "type": "aiMessage"}
{"data": ",", "lastEventId": "1743910476251", "type": "aiMessage"}
{"data": " 알", "lastEventId": "1743910476251", "type": "aiMessage"}
{"data": "겠", "lastEventId": "1743910476264", "type": "aiMessage"}
{"data": "어", "lastEventId": "1743910476265", "type": "aiMessage"}
{"data": "!", "lastEventId": "1743910476285", "type": "aiMessage"}
{"data": " 오늘", "lastEventId": "1743910476286", "type": "aiMessage"}
```

> [!NOTE]
>   OpenAI SDK와 react-native-sse를 사용해 구현할 때는 왜 이런 문제가 없었을까?

OpenAI SDK 응답에서는 `event.data`로 바로 문자열이 들어오지 않고, 객체가 들어왔었다. 그래서 사용할 때 `JSON.parse()`를 사용해 `deserialization` 해서 생성된 문자열에 접근했었다. [(참고 문서)](https://github.com/binaryminds/react-native-sse?tab=readme-ov-file#-usage-with-chatgpt)

즉, `serialization`된 객체가 `event.data`로 들어온다고 가정되어 있었기 때문에 `react-native-sse` 라이브러리에서도 정규식으로 공백을 제거하도록 되어있던 것이다.

반면, 우리는 `event.data` 내에 바로 문자열을 넣었기 때문에 문제가 발생했던 것이다.

다만, 백엔드 DTO를 수정하는 방향으로 해결하면 기존 앱 버전과의 심각한 충돌이 발생하기 때문에, 앱에서 정규식 로직을 수정하는 방향으로 해결하는 것이 맞다고 판단했다.

## ✨ 작업한 내용

- [x] 문제 원인 파악
- [x] react-native-sse 라이브러리의 정규식 로직 수정

## 📷스크린샷 / 영상

https://github.com/user-attachments/assets/fde24198-b3b4-4e08-9839-2b31307e423b
