### PR TITLE
[dev] 채팅 페이지에서 AI 프로필 리스트를 열 때 키보드가 닫히도록 개선

### DIFF
--- a/src/features/chatting/hooks/useChatting.ts
+++ b/src/features/chatting/hooks/useChatting.ts
@@ -1,4 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { Keyboard } from "react-native";
 import { useEffect, useState } from "react";
 import { useRouter } from "expo-router";
 import EventSource from "react-native-sse";
@@ -7,6 +8,7 @@ import { preventDoublePress } from "@/src/libs/esToolkit";
 import showToast from "@/src/libs/showToast";
 import toastMessage from "@/src/constants/toastMessage";
 import endpoint from "@/src/constants/endpoint";
+import { useIsKeyboardOpen } from "./useIsKeyboardOpen";
 import { useMessagesQuery } from "./queries/useMessagesQuery";
 import { useDiaryMutation } from "./mutations/useDiaryMutation";
 import { useChangeAssistantMutation } from "./mutations/useChangeAssistantMutation";
@@ -16,6 +18,7 @@ import type { FluxEventDTO, MessagesDTO, TThreadDate } from "../types/chattingTy
 export const useChatting = (threadDate: TThreadDate, threadExpiredDate: Date, readonly?: boolean) => {
   const queryClient = useQueryClient();
   const router = useRouter();
+  const isKeyboardOpen = useIsKeyboardOpen();
 
   const [input, setInput] = useState<string>("");
   const [isCanDiarySummary, setIsCanDiarySummary] = useState<boolean>(false);
@@ -27,6 +30,7 @@ export const useChatting = (threadDate: TThreadDate, threadExpiredDate: Date, re
   const { mutate: changeAssistantMutate } = useChangeAssistantMutation(setIsVisible);
 
   const handleHeaderPress = () => {
+    if (isKeyboardOpen) Keyboard.dismiss();
     setIsVisible(true);
   };
 


### PR DESCRIPTION
## 👀 관련 이슈

close #68 

## ✨ 작업한 내용

채팅 비즈니스 로직이 담긴 `useChatting`에서 `useIsKeyboardOpen` 훅을 사용해 현재 키보드가 열려있는지를 가져온다.

헤더를 누르면 실행되는 콜백 함수에서 만약 키보드가 열려있다면, 키보드를 닫고 AI 프로필 리스트를 열도록 로직을 추가해줬다.

- [x] 키보드가 열려있는 경우, AI리스트가 열리지 않도록 조건 추가

## 📷스크린샷 / 영상

https://github.com/user-attachments/assets/a6ede742-187f-4754-8897-59fa5a9180da


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 채팅 화면에서 헤더를 누를 때 키보드가 열려 있으면 자동으로 키보드를 닫도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->