### PR TITLE
[dev] EAS Update 시 production 브랜치를 사용하도록 Github Actions 스크립트 변경

### DIFF
--- a/.github/workflows/eas-update.yaml
+++ b/.github/workflows/eas-update.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: 🚀 Run EAS Update
         if: contains(github.event.pull_request.labels.*.name, 'production-update')
-        run: GOOGLE_IOS_URL_SCHEME=${{ secrets.GOOGLE_IOS_URL_SCHEME }} eas update --environment production --auto --non-interactive
+        run: GOOGLE_IOS_URL_SCHEME=${{ secrets.GOOGLE_IOS_URL_SCHEME }} eas update --branch production --environment production --auto --non-interactive
 
       - name: 🚀 Run EAS Build and Submit
         if: contains(github.event.pull_request.labels.*.name, 'production-build-submit')


### PR DESCRIPTION
## 👀 관련 이슈

close #89 

## ✨ 작업한 내용

- [x] EAS Update 시 production 브랜치를 사용하도록 Github Actions 스크립트 변경