### PR TITLE
[dev] 설정 페이지의 자는 시간 description 롤백

### DIFF
--- a/src/features/setting/components/SleepTimeSettingItem.tsx
+++ b/src/features/setting/components/SleepTimeSettingItem.tsx
@@ -14,7 +14,7 @@ export default function SleepTimeSettingItem({ sleepTime, showDatePicker }: Slee
     <S.ItemButton hitSlop={10} onPress={handleButtonPress}>
       <S.ItemTitleBox>
         <S.ItemTitleText>자는 시간 설정</S.ItemTitleText>
-        <S.ItemDescriptionText>해당 시간에 대화를 초기화 해드려요 123 456</S.ItemDescriptionText>
+        <S.ItemDescriptionText>해당 시간에 대화를 초기화 해드려요</S.ItemDescriptionText>
       </S.ItemTitleBox>
       <S.ItemValueText>{sleepTime.slice(0, -3)}</S.ItemValueText>
     </S.ItemButton>


### PR DESCRIPTION
## 👀 관련 이슈

close #78 

## ✨ 작업한 내용

- [x] 설정 페이지의 자는 시간 description 롤백

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 설정 화면의 수면 시간 설명에서 불필요한 숫자("123 456")가 제거되어 문구가 더 깔끔하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->