### PR TITLE
[dev] 일기 요약 속도 향상을 위한 V2 API 연동 작업 및 Placeholder 이미지 구현

### DIFF
--- a/src/components/ui/CachedImage/index.tsx
+++ b/src/components/ui/CachedImage/index.tsx
@@ -1,7 +1,7 @@
 import * as FileSystem from "expo-file-system";
 import { Image } from "expo-image";
 import { useEffect, useState } from "react";
-import { CachedImageProps } from "./types";
+import type { CachedImageProps } from "./types";
 
 function CachedImage({ src, ...rest }: CachedImageProps): JSX.Element {
   const [cachedSource, setCachedSource] = useState<undefined | { uri: string }>(undefined);

--- a/src/components/ui/PlaceholderImage/PlaceholderImage.tsx
+++ b/src/components/ui/PlaceholderImage/PlaceholderImage.tsx
@@ -1,0 +1,73 @@
+import { ImageProps } from "expo-image";
+import CachedImage from "../CachedImage";
+import styled from "styled-components/native";
+import { Animated, Easing, type LayoutChangeEvent } from "react-native";
+import { useEffect, useRef, useState } from "react";
+
+const PLACEHOLDER_IMG_SRC = "https://melissa-s3.s3.ap-northeast-2.amazonaws.com/default.png";
+
+export const PlaceholderImage = (props: Omit<ImageProps, "src">) => {
+  const [width, setWidth] = useState<number>(0);
+
+  const translateX = useRef(new Animated.Value(0)).current;
+
+  const onLayout = (e: LayoutChangeEvent) => {
+    setWidth(e.nativeEvent.layout.width);
+    translateX.setValue(-e.nativeEvent.layout.width);
+  };
+
+  useEffect(() => {
+    if (width === 0) return;
+
+    const animated = Animated.loop(
+      Animated.sequence([
+        Animated.timing(translateX, {
+          toValue: width,
+          duration: 300,
+          useNativeDriver: true,
+          easing: Easing.inOut(Easing.ease),
+        }),
+        Animated.delay(1500),
+        Animated.timing(translateX, {
+          toValue: -width,
+          duration: 0,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+
+    animated.start();
+    return () => animated.stop();
+  }, [translateX, width]);
+
+  return (
+    <Wrapper onLayout={onLayout}>
+      <SCachedImage src={PLACEHOLDER_IMG_SRC} {...props} />
+      <AnimatedShimmer style={{ transform: [{ translateX }] }} />
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.View`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+`;
+
+const SCachedImage = styled(CachedImage)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+const AnimatedShimmer = Animated.createAnimatedComponent(styled.View`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 30%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.2);
+`);

--- a/src/components/ui/PlaceholderImage/index.ts
+++ b/src/components/ui/PlaceholderImage/index.ts
@@ -1,0 +1,1 @@
+export * from "./PlaceholderImage";

--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -8,7 +8,8 @@ const endpoint = {
     refresh: "/api/v1/auth/refresh",
   },
   aiProfile: {
-    aiProfile: "/api/v1/ai-profiles",
+    aiProfilesV1: "/api/v1/ai-profiles",
+    aiProfilesV2: "/api/v2/ai-profiles",
     recent: "/api/v1/ai-profiles/recent",
   },
   setting: {
@@ -27,6 +28,6 @@ const endpoint = {
     day: "/api/v1/calender/day",
     diaries: "/api/v1/calender/month/summary",
   },
-};
+} as const;
 
 export default endpoint;

--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -20,7 +20,7 @@ const endpoint = {
     chat: "/api/v1/chats",
     send: "/api/v1/chats/message",
     changeAi: "/api/v1/chats/ai-profile",
-    summary: "/api/v1/summary",
+    summary: "/api/v2/summary",
   },
   calendar: {
     month: "/api/v1/calender/month",

--- a/src/features/assistantList/components/ProfileImage.tsx
+++ b/src/features/assistantList/components/ProfileImage.tsx
@@ -1,30 +1,28 @@
 import styled from "styled-components/native";
 import CachedImage from "@/src/components/ui/CachedImage";
 import responsiveToPx from "@/src/utils/responsiveToPx";
+import { PlaceholderImage } from "@/src/components/ui/PlaceholderImage";
 
 type ProfileImageProps = {
-  url: string;
+  url: string | null;
 };
 
 export default function ProfileImage({ url }: ProfileImageProps) {
-  return (
-    <ImageBox>
-      <Image src={url} />
-    </ImageBox>
-  );
+  return <ImageBox>{url ? <Image src={url} /> : <PlaceholderImage />}</ImageBox>;
 }
 
 const ImageBox = styled.View`
   width: ${responsiveToPx("300px")};
   height: ${responsiveToPx("300px")};
   background-color: ${({ theme }) => theme.colors.whiteBlue};
+  padding: 3px;
   border-radius: 5px;
   justify-content: center;
   align-items: center;
+  overflow: hidden;
 `;
 
 const Image = styled(CachedImage)`
   width: ${responsiveToPx("295px")};
   height: ${responsiveToPx("295px")};
-  border-radius: 5px;
 `;

--- a/src/features/assistantList/hooks/mutations/useRemoveAssistantMutation.ts
+++ b/src/features/assistantList/hooks/mutations/useRemoveAssistantMutation.ts
@@ -6,7 +6,7 @@ import endpoint from "@/src/constants/endpoint";
 import type { SuccessDTO } from "@/src/types/commonTypes";
 
 const _removeAssistant = async (aiProfileId: number) => {
-  const { data } = await axiosInstance.delete<SuccessDTO>(`${endpoint.aiProfile.aiProfile}/${aiProfileId}`);
+  const { data } = await axiosInstance.delete<SuccessDTO>(`${endpoint.aiProfile.aiProfilesV1}/${aiProfileId}`);
   return data;
 };
 

--- a/src/features/assistantList/hooks/queries/useAssistantListQuery.ts
+++ b/src/features/assistantList/hooks/queries/useAssistantListQuery.ts
@@ -3,15 +3,25 @@ import axiosInstance from "@/src/libs/axiosInstance";
 import endpoint from "@/src/constants/endpoint";
 import type { AssistantProfileListDTO, TAssistantProfile, TNewAiTrigger } from "../../types/assistantListTypes";
 
-export const _assistantListWithNewAiTrigger = async () => {
-  const { data } = await axiosInstance.get<AssistantProfileListDTO>(endpoint.aiProfile.aiProfile);
+export const _getAssistantListWithNewAiTrigger = async () => {
+  const { data } = await axiosInstance.get<AssistantProfileListDTO>(endpoint.aiProfile.aiProfilesV1);
   const dataWithNewAiTrigger: (TAssistantProfile | TNewAiTrigger)[] = [...data.result, { isGenerateButton: true }];
   return dataWithNewAiTrigger;
 };
 
+const _isAssistantProfile = (item: TAssistantProfile | TNewAiTrigger): item is TAssistantProfile => {
+  return (item as TAssistantProfile).aiProfileId !== undefined;
+};
+
 export const useAssistantListQuery = () => {
   return useQuery({
-    queryFn: _assistantListWithNewAiTrigger,
+    queryFn: _getAssistantListWithNewAiTrigger,
     queryKey: ["assistant-list"],
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return 3000;
+      const isRefetch = data.filter(_isAssistantProfile).find((d) => !!d.profileName && !d.imageUrl);
+      return isRefetch ? 2000 : false;
+    },
   });
 };

--- a/src/features/assistantList/types/assistantListTypes.ts
+++ b/src/features/assistantList/types/assistantListTypes.ts
@@ -3,7 +3,7 @@ import type { SuccessDTO } from "@/src/types/commonTypes";
 export type TAssistantProfile = {
   aiProfileId: number;
   profileName: string;
-  imageUrl: string;
+  imageUrl: string | null;
   hashTag1: string;
   hashTag2: string;
   feature1: string;

--- a/src/features/chatting/components/AiChatBox.tsx
+++ b/src/features/chatting/components/AiChatBox.tsx
@@ -2,16 +2,17 @@ import styled from "styled-components/native";
 import CachedImage from "@/src/components/ui/CachedImage";
 import responsiveToPx from "@/src/utils/responsiveToPx";
 import { shadowProps } from "@/src/constants/shadowProps";
+import { PlaceholderImage } from "@/src/components/ui/PlaceholderImage";
 
 type AiChatBoxProps = {
   content: string;
-  imageUrl: string;
+  imageUrl: string | null;
 };
 
 export default function AiChatBox({ content, imageUrl }: AiChatBoxProps) {
   return (
     <AiChatLayout>
-      <Image src={imageUrl} />
+      <ImageBox>{imageUrl ? <Image src={imageUrl} /> : <PlaceholderImage />}</ImageBox>
       <AiChatTextBox style={shadowProps}>
         <AiChatText>{content}</AiChatText>
       </AiChatTextBox>
@@ -26,10 +27,16 @@ const AiChatLayout = styled.View`
   gap: ${({ theme }) => theme.gap.md};
 `;
 
-const Image = styled(CachedImage)`
+const ImageBox = styled.View`
   width: ${responsiveToPx("36px")};
   height: ${responsiveToPx("36px")};
   border-radius: 9999px;
+  overflow: hidden;
+`;
+
+const Image = styled(CachedImage)`
+  width: 100%;
+  height: 100%;
 `;
 
 const AiChatTextBox = styled.View`

--- a/src/features/chatting/components/ChatHeader.tsx
+++ b/src/features/chatting/components/ChatHeader.tsx
@@ -4,9 +4,10 @@ import { MaterialIcons } from "@expo/vector-icons";
 import CachedImage from "@/src/components/ui/CachedImage";
 import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 import { theme } from "@/src/constants/theme";
+import { PlaceholderImage } from "@/src/components/ui/PlaceholderImage";
 
 type ChatHeaderProps = {
-  imageSrc: string;
+  imageSrc: string | null;
   assistantName: string;
   onPress: () => void;
   readonly?: boolean;
@@ -21,7 +22,7 @@ export default function ChatHeader({ imageSrc, assistantName, onPress, readonly 
         <MaterialIcons name="arrow-back-ios" size={28} color={theme.colors.black} />
       </BackButton>
       <HeaderButton onPress={onPress} hitSlop={7} disabled={readonly}>
-        <Image src={imageSrc} />
+        <ImageBox>{imageSrc ? <Image src={imageSrc} /> : <PlaceholderImage />}</ImageBox>
         <AiNameText>{assistantName}</AiNameText>
       </HeaderButton>
     </HeaderBox>
@@ -51,10 +52,16 @@ const HeaderButton = styled.TouchableOpacity`
   align-items: center;
 `;
 
-const Image = styled(CachedImage)`
+const ImageBox = styled.View`
   width: ${responsiveToPx("48px")};
   height: ${responsiveToPx("48px")};
   border-radius: 9999px;
+  overflow: hidden;
+`;
+
+const Image = styled(CachedImage)`
+  width: 100%;
+  height: 100%;
 `;
 
 const AiNameText = styled.Text`

--- a/src/features/chatting/hooks/queries/useMessagesQuery.ts
+++ b/src/features/chatting/hooks/queries/useMessagesQuery.ts
@@ -16,5 +16,11 @@ export const useMessagesQuery = ({ year, month, day }: TThreadDate) => {
   return useQuery({
     queryFn: () => _getMessages({ year, month, day }),
     queryKey: ["messages", year, month, day],
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return 3000;
+      const isRefetch = !!data.result.aiProfileName && !data.result.aiProfileImageS3;
+      return isRefetch ? 2000 : false;
+    },
   });
 };

--- a/src/features/chatting/types/chattingTypes.ts
+++ b/src/features/chatting/types/chattingTypes.ts
@@ -6,7 +6,7 @@ export type TChat = {
   content: string;
   createAt: string;
   aiProfileName: string;
-  aiProfileImageS3: string;
+  aiProfileImageS3: string | null;
 };
 
 export type NewThreadDTO = SuccessDTO & {
@@ -21,7 +21,7 @@ export type NewThreadDTO = SuccessDTO & {
 export type MessagesDTO = SuccessDTO & {
   result: {
     aiProfileName: string;
-    aiProfileImageS3: string;
+    aiProfileImageS3: string | null;
     chats: TChat[];
   };
 };

--- a/src/features/main/components/DayComponent.tsx
+++ b/src/features/main/components/DayComponent.tsx
@@ -31,7 +31,8 @@ export default function DayComponent({ date, onPress }: DayComponentProps) {
   return (
     <DayBox onPress={() => onPress(date)}>
       <ImageBox>
-        <Image src={dayDiary.imageS3} />
+        {/* Todo: placeholder 이미지로 변경되면, 타입 정리 필요 */}
+        <Image src={dayDiary.imageS3 ?? ""} />
       </ImageBox>
       <TagBox>
         <TagText numberOfLines={1} ellipsizeMode="clip">

--- a/src/features/main/components/DayComponent.tsx
+++ b/src/features/main/components/DayComponent.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components/native";
 import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 import CachedImage from "@/src/components/ui/CachedImage";
 import { useCalendarQuery } from "../hooks/queries/useCalendarQuery";
+import { PlaceholderImage } from "@/src/components/ui/PlaceholderImage";
 
 type DayComponentProps = Omit<BasicDayProps, "date"> & {
   date?: DateData;
@@ -30,10 +31,7 @@ export default function DayComponent({ date, onPress }: DayComponentProps) {
 
   return (
     <DayBox onPress={() => onPress(date)}>
-      <ImageBox>
-        {/* Todo: placeholder 이미지로 변경되면, 타입 정리 필요 */}
-        <Image src={dayDiary.imageS3 ?? ""} />
-      </ImageBox>
+      <ImageBox>{dayDiary.imageS3 ? <Image src={dayDiary.imageS3} /> : <PlaceholderImage />}</ImageBox>
       <TagBox>
         <TagText numberOfLines={1} ellipsizeMode="clip">
           {dayDiary.hashTag1}

--- a/src/features/main/components/DiaryBottomSheet.tsx
+++ b/src/features/main/components/DiaryBottomSheet.tsx
@@ -48,7 +48,8 @@ export default forwardRef(function DiaryBottomSheet(
         <BottomSheetLayout>
           <ScrollBox showsVerticalScrollIndicator={false}>
             <ImageBox>
-              <Image src={diary.imageS3} />
+              {/* Todo: placeholder 이미지로 변경되면, 타입 정리 필요 */}
+              <Image src={diary.imageS3 ?? ""} />
             </ImageBox>
             <DateText>
               {diary.year}. {diary.month}. {diary.day}

--- a/src/features/main/components/DiaryBottomSheet.tsx
+++ b/src/features/main/components/DiaryBottomSheet.tsx
@@ -10,6 +10,7 @@ import { theme } from "@/src/constants/theme";
 import { shadowProps } from "@/src/constants/shadowProps";
 import { useDiariesQuery } from "../hooks/queries/useDiariesQuery";
 import DiaryBottomSheetBackdrop from "./DiaryBottomSheetBackdrop";
+import { PlaceholderImage } from "@/src/components/ui/PlaceholderImage";
 
 type DiaryBottomSheetProps = {
   pressedDate: Pick<DateData, "year" | "month" | "day">;
@@ -47,10 +48,7 @@ export default forwardRef(function DiaryBottomSheet(
       {diary && (
         <BottomSheetLayout>
           <ScrollBox showsVerticalScrollIndicator={false}>
-            <ImageBox>
-              {/* Todo: placeholder 이미지로 변경되면, 타입 정리 필요 */}
-              <Image src={diary.imageS3 ?? ""} />
-            </ImageBox>
+            <ImageBox>{diary.imageS3 ? <Image src={diary.imageS3} /> : <PlaceholderImage />}</ImageBox>
             <DateText>
               {diary.year}. {diary.month}. {diary.day}
             </DateText>

--- a/src/features/main/hooks/queries/useCalendarQuery.ts
+++ b/src/features/main/hooks/queries/useCalendarQuery.ts
@@ -12,6 +12,12 @@ export const useCalendarQuery = ({ year, month }: TProps) => {
     queryFn: year && month ? () => _calendar(year, month) : skipToken,
     queryKey: ["calendar", year, month],
     staleTime: 5 * 60 * 1000,
-    select: (data: CalendarDTO) => data.result.filter((calendar): calendar is TDay => !!calendar.imageS3),
+    select: (data: CalendarDTO) => data.result.filter((calendar): calendar is TDay => !!calendar.hashTag1),
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return 3000;
+      const isRefetch = data.result.find((d) => !!d.hashTag1 && !d.imageS3);
+      return isRefetch ? 2000 : false;
+    },
   });
 };

--- a/src/features/main/hooks/queries/useDiariesQuery.ts
+++ b/src/features/main/hooks/queries/useDiariesQuery.ts
@@ -13,5 +13,11 @@ export const useDiariesQuery = ({ year, month }: TProps) => {
     queryKey: ["diaries", year, month],
     staleTime: 5 * 60 * 1000,
     select: (data: DiariesDTO) => data.result.filter((diary): diary is TDiary => !!diary.imageS3),
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return 3000;
+      const isRefetch = data.result.find((d) => !!d.summaryTitle && !d.imageS3);
+      return isRefetch ? 2000 : false;
+    },
   });
 };

--- a/src/features/main/hooks/queries/useDiariesQuery.ts
+++ b/src/features/main/hooks/queries/useDiariesQuery.ts
@@ -12,7 +12,7 @@ export const useDiariesQuery = ({ year, month }: TProps) => {
     queryFn: () => _diaries(year, month),
     queryKey: ["diaries", year, month],
     staleTime: 5 * 60 * 1000,
-    select: (data: DiariesDTO) => data.result.filter((diary): diary is TDiary => !!diary.imageS3),
+    select: (data: DiariesDTO) => data.result.filter((diary): diary is TDiary => !!diary.hashTag1),
     refetchInterval: (query) => {
       const data = query.state.data;
       if (!data) return 3000;

--- a/src/features/main/types/calendarTypes.ts
+++ b/src/features/main/types/calendarTypes.ts
@@ -13,7 +13,6 @@ export type TNullableDay = {
   imageS3: string | null;
 };
 
-// Todo: placeholder 이미지로 변경되면, 타입 정리 필요
 export type TDay = Omit<ObjectNonNullable<TNullableDay>, "imageS3"> & { imageS3: string | null };
 
 export type TNullableDiary = {
@@ -28,7 +27,6 @@ export type TNullableDiary = {
   summaryMood: ("HAPPY" | "SAD" | "TIRED" | "ANGRY" | "RELAX") | null;
 };
 
-// Todo: placeholder 이미지로 변경되면, 타입 정리 필요
 export type TDiary = Omit<ObjectNonNullable<TNullableDiary>, "imageS3"> & { imageS3: string | null };
 
 export type CalendarDTO = SuccessDTO & {

--- a/src/features/main/types/calendarTypes.ts
+++ b/src/features/main/types/calendarTypes.ts
@@ -13,7 +13,8 @@ export type TNullableDay = {
   imageS3: string | null;
 };
 
-export type TDay = ObjectNonNullable<TNullableDay>;
+// Todo: placeholder 이미지로 변경되면, 타입 정리 필요
+export type TDay = Omit<ObjectNonNullable<TNullableDay>, "imageS3"> & { imageS3: string | null };
 
 export type TNullableDiary = {
   year: number;
@@ -27,7 +28,8 @@ export type TNullableDiary = {
   summaryMood: ("HAPPY" | "SAD" | "TIRED" | "ANGRY" | "RELAX") | null;
 };
 
-export type TDiary = ObjectNonNullable<TNullableDiary>;
+// Todo: placeholder 이미지로 변경되면, 타입 정리 필요
+export type TDiary = Omit<ObjectNonNullable<TNullableDiary>, "imageS3"> & { imageS3: string | null };
 
 export type CalendarDTO = SuccessDTO & {
   result: (TNullableDay | TDay)[];

--- a/src/features/makeAssistant/apis/makeAssistantApi.ts
+++ b/src/features/makeAssistant/apis/makeAssistantApi.ts
@@ -3,6 +3,6 @@ import endpoint from "@/src/constants/endpoint";
 import type { MakeAssistantDTO, TAssistantMakeQnA } from "../types/makeAssistantTypes";
 
 export const _makeAssistant = async (answers: TAssistantMakeQnA) => {
-  const { data } = await axiosInstance.post<MakeAssistantDTO>(endpoint.aiProfile.aiProfile, answers);
+  const { data } = await axiosInstance.post<MakeAssistantDTO>(endpoint.aiProfile.aiProfilesV2, answers);
   return data;
 };

--- a/src/features/makeAssistant/hooks/queries/useMakeAssistantQuestionQuery.ts
+++ b/src/features/makeAssistant/hooks/queries/useMakeAssistantQuestionQuery.ts
@@ -1,19 +1,19 @@
 import axiosInstance from "@/src/libs/axiosInstance";
 import endpoint from "@/src/constants/endpoint";
 import type { MakeAssistantQuestionDTO } from "../../types/makeAssistantTypes";
-import { useQuery } from "@tanstack/react-query";
+import { skipToken, useQuery } from "@tanstack/react-query";
 
 const _getAssistantQuestion = async (aiProfileId: string) => {
   const { data } = await axiosInstance.get<MakeAssistantQuestionDTO>(
-    `${endpoint.aiProfile.aiProfile}/${aiProfileId}/question`
+    `${endpoint.aiProfile.aiProfilesV1}/${aiProfileId}/question`
   );
   return data;
 };
 
 export const useMakeAssistantQuestionQuery = (aiProfileId?: string) => {
   return useQuery({
-    queryFn: () => (aiProfileId ? _getAssistantQuestion(aiProfileId) : Promise.reject("No aiProfileId")),
-    queryKey: ["make-assistant-question", aiProfileId ?? ""],
+    queryFn: !!aiProfileId ? () => _getAssistantQuestion(aiProfileId) : skipToken,
+    queryKey: ["make-assistant-question", aiProfileId],
     enabled: !!aiProfileId,
   });
 };


### PR DESCRIPTION
## 👀 관련 이슈

close #99 

## ✨ 작업한 내용

- [x] 일기 요약 mutation API를 v2로 교체
- [x] 캘린더 query(useCalendarQuery)에 `refetchInterval`을 추가해 생성중인 일기만 주기적으로 refetch하도록 구현
- [x] 일기 상세 query(useDiariesQuery)에 `refetchInterval`을 추가해 생성중인 일기 상세만 주기적으로 refetch하도록 구현
- [x] 이미지 필드가 null이면, Placeholder 이미지와 shimmer 효과가 젹용된 컴포넌트를 렌더링하도록 구현

## 📷스크린샷 / 영상

<table>
  <tr>
    <td>테스트</td>
    <td><img width="224" src="https://github.com/user-attachments/assets/f5fdf6a8-0e7b-407c-b6eb-573849150c32" /></td>
  </tr>
</table>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - 이미지가 없는 경우 표시되는 플레이스홀더 이미지 및 반짝임 애니메이션이 추가되었습니다.

- **Bug Fixes**
  - 일부 화면에서 이미지가 없을 때 빈 공간 대신 플레이스홀더 이미지가 표시됩니다.

- **Chores**
  - 일부 API 엔드포인트가 최신 버전으로 업데이트되었습니다.
  - 데이터 조회 및 자동 갱신 조건이 개선되었습니다.

- **Refactor**
  - 타입 정의에서 이미지 관련 속성의 null 허용 범위가 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->