### PR TITLE
[dev] Android 채팅 페이지 하단 뚫림 문제 대응

### DIFF
--- a/src/features/chatting/components/ChatInput.tsx
+++ b/src/features/chatting/components/ChatInput.tsx
@@ -35,7 +35,6 @@ export default function ChatInput({ input, setInput, onSubmitPress, readonly }: 
 }
 
 const KeyboardAvoidingBox = styled.KeyboardAvoidingView`
-  width: 100%;
   background-color: ${({ theme }) => theme.colors.whiteBlue};
   justify-content: center;
   align-items: center;

--- a/src/features/chatting/containers/ChattingContainer.tsx
+++ b/src/features/chatting/containers/ChattingContainer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
-import { ScrollView } from "react-native";
+import { Platform, ScrollView } from "react-native";
 import styled from "styled-components/native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { type Edge, SafeAreaView } from "react-native-safe-area-context";
 import ChatHeader from "../components/ChatHeader";
 import AiChatBox from "../components/AiChatBox";
 import UserChatBox from "../components/UserChatBox";
@@ -38,6 +38,14 @@ const ChattingContainer = ({ threadDate, threadExpiredDate, readonly }: Props) =
 
   const { data: messages } = useMessagesQuery(threadDate);
   const { isPending: isSavePending, mutate: saveMutate } = useDiaryMutation(threadDate);
+
+  const getSafeViewEdges = (): Edge[] => {
+    const os = Platform.OS;
+    if (os === "android") {
+      return ["top", "left", "right", "bottom"];
+    }
+    return ["top", "left", "right"];
+  };
 
   const handleSaveMutate = () => {
     if (isSavePending) return;
@@ -163,7 +171,7 @@ const ChattingContainer = ({ threadDate, threadExpiredDate, readonly }: Props) =
   }, [queryClient]);
 
   return (
-    <SafeView edges={["left", "right", "top"]}>
+    <SafeView edges={getSafeViewEdges()}>
       <ChatHeader
         imageSrc={messages?.result.aiProfileImageS3 ?? ""}
         assistantName={messages?.result.aiProfileName ?? ""}


### PR DESCRIPTION
## 👀 관련 이슈

> github issue 티켓 번호를 명시해서 PR이 merge되면 issue가 close되도록 해주세요.   

close #132 

## ✨ 작업한 내용

> 작업한 내용을 정리해서 설명해주세요. 커밋 단위가 적절하지 못하다면, 체크박스를 활용해 어떤 작업을 진행했는지 정리해주세요.

- [x] android/ios에서 각각 `SafeAreaView`의 `edge`를 다르게 지정 (안드로이드는 4면 모두, IOS는 하단 제외)

## 📷스크린샷 / 영상

> 작업 결과물을 스크린샷, 영상 등으로 확인할 수 있게 제공해주세요.

<img width="809" height="826" alt="스크린샷 2025-08-01 22 27 24" src="https://github.com/user-attachments/assets/fe441c95-6ca6-4cf4-82a5-6ee43e9de334" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 채팅 입력창의 스타일에서 전체 너비(`width: 100%`) 속성이 제거되었습니다.

* **버그 수정**
  * Android 기기에서 채팅 화면의 안전 영역(Safe Area)이 이제 하단까지 올바르게 적용되어, 화면 요소가 잘리지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->