### PR TITLE
[main] 일기 수동 작성 기능 구현

### DIFF
--- a/src/constants/endpoint.ts
+++ b/src/constants/endpoint.ts
@@ -27,6 +27,7 @@ const endpoint = {
     month: "/api/v1/calender/month",
     day: "/api/v1/calender/day",
     diaries: "/api/v1/calender/month/summary",
+    createDiary: "/api/v2/chats/manual",
   },
 } as const;
 

--- a/src/constants/toastMessage.ts
+++ b/src/constants/toastMessage.ts
@@ -38,6 +38,10 @@ const toastMessage = {
     success: "일기가 업데이트 되었습니다.",
     error: "일기 생성에 실패했습니다.",
   },
+  createDiary: {
+    success: "일기가 작성되었습니다.",
+    error: "일기 작성에 실패했습니다.",
+  },
 };
 
 export default toastMessage;

--- a/src/features/main/components/DayComponent.tsx
+++ b/src/features/main/components/DayComponent.tsx
@@ -1,16 +1,19 @@
-import type { BasicDayProps } from "react-native-calendars/src/calendar/day/basic";
-import type { DateData } from "react-native-calendars";
 import styled from "styled-components/native";
 import { Image } from "expo-image";
+import type { BasicDayProps } from "react-native-calendars/src/calendar/day/basic";
+import type { DateData } from "react-native-calendars";
 import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
-import { useCalendarQuery } from "../hooks/queries/useCalendarQuery";
 import { PlaceholderImage } from "@/src/components/ui/PlaceholderImage";
+import { useModal } from "@/src/modules/modal";
+import { useCalendarQuery } from "../hooks/queries/useCalendarQuery";
+import ManualDiaryModal from "./modals/ManualDiaryModal";
 
 type DayComponentProps = Omit<BasicDayProps, "date"> & {
   date?: DateData;
 };
 
 export default function DayComponent({ date, onPress }: DayComponentProps) {
+  const manualDiaryModal = useModal();
   const { data } = useCalendarQuery({ year: date?.year, month: date?.month });
 
   if (!date || !data || !onPress) return null;
@@ -19,9 +22,15 @@ export default function DayComponent({ date, onPress }: DayComponentProps) {
     (calendar) => calendar.year === date.year && calendar.month === date.month && calendar.day === date.day
   );
 
+  const handleManualDiaryModalOpen = () => {
+    manualDiaryModal.open((modalProps) => {
+      return <ManualDiaryModal {...modalProps} date={date} />;
+    });
+  };
+
   if (!dayDiary) {
     return (
-      <DayBox disabled={true}>
+      <DayBox onPress={handleManualDiaryModalOpen}>
         <ImageBox>
           <DayText>{date.day}</DayText>
         </ImageBox>

--- a/src/features/main/components/modals/ManualDiaryModal.tsx
+++ b/src/features/main/components/modals/ManualDiaryModal.tsx
@@ -4,6 +4,8 @@ import { ModalRoot, type ModalProps } from "@/src/modules/modal";
 import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 import { theme } from "@/src/constants/theme";
 import { useState } from "react";
+import { useManualDiaryMutation } from "../../hooks/mutations/useManualDiaryMutation";
+import { Keyboard } from "react-native";
 
 type Props = ModalProps & {
   date: DateData;
@@ -14,8 +16,21 @@ const ManualDiaryModal = ({ isOpen, close, exit, date }: Props) => {
   const [content, setContent] = useState<string>("");
   const [hashtag1, setHashtag1] = useState<string>("");
   const [hashtag2, setHashtag2] = useState<string>("");
-
   const isSubmitable = !!title && !!content && !!hashtag1 && !!hashtag2;
+
+  const manualDiaryMutation = useManualDiaryMutation();
+
+  const handleSubmitSuccess = () => {
+    Keyboard.dismiss();
+    exit();
+  };
+
+  const handleSubmitPress = () => {
+    if (manualDiaryMutation.isPending) return;
+
+    const diary = { title, content, hashtag1, hashtag2 };
+    manualDiaryMutation.mutate({ date, diary }, { onSuccess: handleSubmitSuccess });
+  };
 
   return (
     <ModalRoot isOpen={isOpen} onClose={close}>
@@ -53,7 +68,7 @@ const ManualDiaryModal = ({ isOpen, close, exit, date }: Props) => {
             placeholderTextColor={theme.colors.placeholderText}
           />
         </HashtagInputWrapper>
-        <SubmitButton disabled={!isSubmitable}>
+        <SubmitButton disabled={!isSubmitable} onPress={handleSubmitPress}>
           <SubmitButtonText>저장하기</SubmitButtonText>
         </SubmitButton>
       </Wrapper>

--- a/src/features/main/components/modals/ManualDiaryModal.tsx
+++ b/src/features/main/components/modals/ManualDiaryModal.tsx
@@ -1,0 +1,60 @@
+import styled from "styled-components/native";
+import type { DateData } from "react-native-calendars";
+import { ModalRoot, type ModalProps } from "@/src/modules/modal";
+import responsiveToPx from "@/src/utils/responsiveToPx";
+import { theme } from "@/src/constants/theme";
+import { useState } from "react";
+
+type Props = ModalProps & {
+  date: DateData;
+};
+
+const ManualDiaryModal = ({ isOpen, close, exit, date }: Props) => {
+  const [title, setTitle] = useState<string>("");
+
+  return (
+    <ModalRoot isOpen={isOpen} onClose={close}>
+      <Wrapper>
+        <Title>일기 작성</Title>
+        <TitleInput
+          value={title}
+          onChangeText={setTitle}
+          placeholder="제목을 작성해주세요..."
+          hitSlop={15}
+          placeholderTextColor={theme.colors.placeholderText}
+        />
+      </Wrapper>
+    </ModalRoot>
+  );
+};
+
+export default ManualDiaryModal;
+
+const Wrapper = styled.View`
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: ${theme.colors.white};
+  padding: ${responsiveToPx("30px")};
+  gap: ${responsiveToPx("20px")};
+  border-radius: ${responsiveToPx("30px")};
+`;
+
+const Title = styled.Text`
+  font-family: ${theme.fontFamily.nsExtraBold};
+  font-size: ${theme.fontSize.lg};
+  color: ${theme.colors.black};
+`;
+
+const TitleInput = styled.TextInput`
+  width: ${responsiveToPx("333px")};
+  max-height: ${responsiveToPx("100px")};
+  padding: ${responsiveToPx("11px")} ${responsiveToPx("16px")};
+  background-color: ${theme.colors.white};
+  border: 1px solid ${theme.colors.gray};
+  border-radius: ${theme.borderRadius.sm};
+  font-family: ${theme.fontFamily.nsRegular};
+  font-size: ${theme.fontSize.base};
+`;

--- a/src/features/main/components/modals/ManualDiaryModal.tsx
+++ b/src/features/main/components/modals/ManualDiaryModal.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components/native";
 import type { DateData } from "react-native-calendars";
 import { ModalRoot, type ModalProps } from "@/src/modules/modal";
-import responsiveToPx from "@/src/utils/responsiveToPx";
+import responsiveToPx, { responsiveToPxByHeight } from "@/src/utils/responsiveToPx";
 import { theme } from "@/src/constants/theme";
 import { useState } from "react";
 
@@ -94,7 +94,7 @@ const TitleInput = styled.TextInput`
 
 const ContentInput = styled.TextInput`
   width: 100%;
-  height: ${responsiveToPx("200px")};
+  height: ${responsiveToPxByHeight("120px")};
   padding: ${responsiveToPx("11px")};
   background-color: ${theme.colors.white};
   border: 1px solid ${theme.colors.gray};

--- a/src/features/main/components/modals/ManualDiaryModal.tsx
+++ b/src/features/main/components/modals/ManualDiaryModal.tsx
@@ -11,6 +11,11 @@ type Props = ModalProps & {
 
 const ManualDiaryModal = ({ isOpen, close, exit, date }: Props) => {
   const [title, setTitle] = useState<string>("");
+  const [content, setContent] = useState<string>("");
+  const [hashtag1, setHashtag1] = useState<string>("");
+  const [hashtag2, setHashtag2] = useState<string>("");
+
+  const isSubmitable = !!title && !!content && !!hashtag1 && !!hashtag2;
 
   return (
     <ModalRoot isOpen={isOpen} onClose={close}>
@@ -23,6 +28,34 @@ const ManualDiaryModal = ({ isOpen, close, exit, date }: Props) => {
           hitSlop={15}
           placeholderTextColor={theme.colors.placeholderText}
         />
+        <ContentInput
+          value={content}
+          onChangeText={setContent}
+          placeholder="일기를 작성해주세요..."
+          hitSlop={15}
+          multiline
+          textAlignVertical="top"
+          placeholderTextColor={theme.colors.placeholderText}
+        />
+        <HashtagInputWrapper>
+          <HashtagInput
+            value={hashtag1}
+            onChangeText={setHashtag1}
+            placeholder="#여행"
+            hitSlop={15}
+            placeholderTextColor={theme.colors.placeholderText}
+          />
+          <HashtagInput
+            value={hashtag2}
+            onChangeText={setHashtag2}
+            placeholder="#행복"
+            hitSlop={15}
+            placeholderTextColor={theme.colors.placeholderText}
+          />
+        </HashtagInputWrapper>
+        <SubmitButton disabled={!isSubmitable}>
+          <SubmitButtonText>저장하기</SubmitButtonText>
+        </SubmitButton>
       </Wrapper>
     </ModalRoot>
   );
@@ -38,8 +71,8 @@ const Wrapper = styled.View`
   align-items: center;
   background-color: ${theme.colors.white};
   padding: ${responsiveToPx("30px")};
-  gap: ${responsiveToPx("20px")};
-  border-radius: ${responsiveToPx("30px")};
+  gap: ${theme.gap.lg};
+  border-radius: ${theme.borderRadius.lg};
 `;
 
 const Title = styled.Text`
@@ -49,12 +82,57 @@ const Title = styled.Text`
 `;
 
 const TitleInput = styled.TextInput`
-  width: ${responsiveToPx("333px")};
-  max-height: ${responsiveToPx("100px")};
-  padding: ${responsiveToPx("11px")} ${responsiveToPx("16px")};
+  width: 100%;
+  height: ${responsiveToPx("45px")};
+  padding: ${responsiveToPx("11px")};
   background-color: ${theme.colors.white};
   border: 1px solid ${theme.colors.gray};
   border-radius: ${theme.borderRadius.sm};
   font-family: ${theme.fontFamily.nsRegular};
   font-size: ${theme.fontSize.base};
+`;
+
+const ContentInput = styled.TextInput`
+  width: 100%;
+  height: ${responsiveToPx("200px")};
+  padding: ${responsiveToPx("11px")};
+  background-color: ${theme.colors.white};
+  border: 1px solid ${theme.colors.gray};
+  border-radius: ${theme.borderRadius.sm};
+  font-family: ${theme.fontFamily.nsRegular};
+  font-size: ${theme.fontSize.base};
+`;
+
+const HashtagInputWrapper = styled.View`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  gap: ${theme.gap.lg};
+`;
+
+const HashtagInput = styled.TextInput`
+  flex: 1;
+  height: ${responsiveToPx("45px")};
+  padding: ${responsiveToPx("11px")};
+  background-color: ${theme.colors.white};
+  border: 1px solid ${theme.colors.gray};
+  border-radius: ${theme.borderRadius.sm};
+  font-family: ${theme.fontFamily.nsRegular};
+  font-size: ${theme.fontSize.base};
+`;
+
+const SubmitButton = styled.TouchableOpacity`
+  width: 100%;
+  height: ${responsiveToPx("45px")};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ disabled }) => (disabled ? theme.colors.gray : theme.colors.deepGreen)};
+  border-radius: ${theme.borderRadius.sm};
+`;
+
+const SubmitButtonText = styled.Text`
+  font-family: ${theme.fontFamily.nsBold};
+  font-size: ${theme.fontSize.base};
+  color: ${theme.colors.white};
 `;

--- a/src/features/main/hooks/mutations/useManualDiaryMutation.ts
+++ b/src/features/main/hooks/mutations/useManualDiaryMutation.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { DateData } from "react-native-calendars";
+import endpoint from "@/src/constants/endpoint";
+import toastMessage from "@/src/constants/toastMessage";
+import axiosInstance from "@/src/libs/axiosInstance";
+import { toast } from "@/src/modules/toast";
+import { CALENDAR_QUERY_KEY } from "../queries/useCalendarQuery";
+import { DIARIES_QUERY_KEY } from "../queries/useDiariesQuery";
+import type { TManualDiaryDTO } from "../../types/calendarTypes";
+
+type Params = {
+  date: DateData;
+  diary: {
+    title: string;
+    content: string;
+    hashtag1: string;
+    hashtag2: string;
+  };
+};
+
+const postManualDiary = async (_params: Params) => {
+  const { date, diary } = _params;
+  const params = { year: date.year, month: date.month, day: date.day };
+  const body = { ...diary, mood: "HAPPY", generateImage: true };
+
+  const result = await axiosInstance.post<TManualDiaryDTO>(endpoint.calendar.createDiary, body, { params });
+  return result.data;
+};
+
+export const useManualDiaryMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: postManualDiary,
+    onSuccess: (_, { date }) => {
+      const { year, month } = date;
+      toast({ message: toastMessage.createDiary.success, options: { type: "success" } });
+      queryClient.invalidateQueries({ queryKey: [CALENDAR_QUERY_KEY, year, month] });
+      queryClient.invalidateQueries({ queryKey: [DIARIES_QUERY_KEY, year, month] });
+    },
+    onError: (error) => {
+      console.error(error.response?.data);
+      toast({ message: toastMessage.createDiary.error, options: { type: "error" } });
+    },
+  });
+};

--- a/src/features/main/types/calendarTypes.ts
+++ b/src/features/main/types/calendarTypes.ts
@@ -29,6 +29,10 @@ export type TNullableDiary = {
 
 export type TDiary = Omit<ObjectNonNullable<TNullableDiary>, "imageS3"> & { imageS3: string | null };
 
+export type TManualDiaryDTO = SuccessDTO & {
+  result: TNullableDiary;
+};
+
 export type CalendarDTO = SuccessDTO & {
   result: (TNullableDay | TDay)[];
 };

--- a/src/modules/modal/components/ModalRoot.tsx
+++ b/src/modules/modal/components/ModalRoot.tsx
@@ -1,6 +1,6 @@
-import styled from "styled-components/native";
-import type { ReactNode } from "react";
 import { type GestureResponderEvent, Modal, TouchableWithoutFeedback } from "react-native";
+import type { ReactNode } from "react";
+import styled from "styled-components/native";
 
 type ModalRootProps = {
   isOpen: boolean;
@@ -18,7 +18,7 @@ export const ModalRoot = ({ isOpen, onClose, children }: ModalRootProps) => {
   };
 
   return (
-    <Modal visible={isOpen} transparent={true} animationType="fade" onRequestClose={onClose}>
+    <Modal visible={isOpen} animationType="fade" onRequestClose={onClose} transparent statusBarTranslucent>
       <TouchableWithoutFeedback onPress={handleBackdropPress}>
         <Backdrop>
           <TouchableWithoutFeedback onPress={handleInnerClick}>{children}</TouchableWithoutFeedback>

--- a/src/modules/modal/components/ModalRoot.tsx
+++ b/src/modules/modal/components/ModalRoot.tsx
@@ -1,4 +1,11 @@
-import { type GestureResponderEvent, Keyboard, Modal, TouchableWithoutFeedback } from "react-native";
+import {
+  type GestureResponderEvent,
+  Keyboard,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  TouchableWithoutFeedback,
+} from "react-native";
 import type { ReactNode } from "react";
 import styled from "styled-components/native";
 import { useIsKeyboardOpen } from "@/src/hooks/useIsKeyboardOpen";
@@ -20,6 +27,22 @@ export const ModalRoot = ({ isOpen, onClose, children }: ModalRootProps) => {
   const handleInnerClick = (e: GestureResponderEvent) => {
     e.stopPropagation();
   };
+
+  // * IOS의 경우, 모달이 열린 상태에서 키보드가 노출되면, 키보드가 모달을 가리는 문제가 존재합니다.
+  // * KeyboardAvoidingView를 활용해 키보드가 노출되면, 모달이 키보드 위로 올라가도록 처리합니다.
+  if (Platform.OS === "ios") {
+    return (
+      <Modal visible={isOpen} animationType="fade" onRequestClose={onClose} transparent>
+        <KeyboardAvoidingView behavior="padding" style={{ flex: 1 }}>
+          <TouchableWithoutFeedback onPress={handleBackdropPress}>
+            <Backdrop>
+              <TouchableWithoutFeedback onPress={handleInnerClick}>{children}</TouchableWithoutFeedback>
+            </Backdrop>
+          </TouchableWithoutFeedback>
+        </KeyboardAvoidingView>
+      </Modal>
+    );
+  }
 
   return (
     <Modal visible={isOpen} animationType="fade" onRequestClose={onClose} transparent statusBarTranslucent>

--- a/src/modules/modal/components/ModalRoot.tsx
+++ b/src/modules/modal/components/ModalRoot.tsx
@@ -1,6 +1,7 @@
-import { type GestureResponderEvent, Modal, TouchableWithoutFeedback } from "react-native";
+import { type GestureResponderEvent, Keyboard, Modal, TouchableWithoutFeedback } from "react-native";
 import type { ReactNode } from "react";
 import styled from "styled-components/native";
+import { useIsKeyboardOpen } from "@/src/hooks/useIsKeyboardOpen";
 
 type ModalRootProps = {
   isOpen: boolean;
@@ -9,8 +10,11 @@ type ModalRootProps = {
 };
 
 export const ModalRoot = ({ isOpen, onClose, children }: ModalRootProps) => {
+  const isKeyboardOpen = useIsKeyboardOpen();
+
   const handleBackdropPress = () => {
-    onClose();
+    if (isKeyboardOpen) return Keyboard.dismiss();
+    return onClose();
   };
 
   const handleInnerClick = (e: GestureResponderEvent) => {

--- a/src/modules/modal/components/Modals.tsx
+++ b/src/modules/modal/components/Modals.tsx
@@ -1,6 +1,6 @@
-import { Fragment } from "react";
 import type { ModalState } from "../types";
 import { useModalDispatch } from "../context/ModalDispatchContext";
+import { View } from "react-native";
 
 type Props = {
   modals: ModalState[];
@@ -14,6 +14,6 @@ export const Modals = ({ modals }: Props) => {
     const close = () => closeModal(id);
     const exit = () => exitModal(id);
 
-    return <Fragment key={id}>{renderFn({ isOpen, close, exit })}</Fragment>;
+    return <View key={id}>{renderFn({ isOpen, close, exit })}</View>;
   });
 };

--- a/src/modules/modal/index.ts
+++ b/src/modules/modal/index.ts
@@ -1,3 +1,4 @@
 export * from "./components/ModalRoot";
 export * from "./provider/ModalsProvider";
 export * from "./hooks/useModal";
+export * from "./types/index";

--- a/src/modules/modal/types/index.ts
+++ b/src/modules/modal/types/index.ts
@@ -4,7 +4,7 @@ export type ModalState = {
   renderFn: ModalRenderFn;
 };
 
-type ModalProps = {
+export type ModalProps = {
   isOpen: boolean;
   close: () => void;
   exit: () => void;


### PR DESCRIPTION
## 👀 관련 이슈

> [!CAUTION]
> **상용 배포 PR**입니다. 

close #155 

## ✨ 작업한 내용

- [x] Android에서 모달이 렌더링되지 않는 문제 대응 (Modal을 View로 감싸야 작동: [Reddit](https://www.reddit.com/r/expo/comments/1i391fi/comment/m85lqdf/?force-legacy-sct=1))
- [x] IOS에서 키보드가 모달을 가리는 문제 대응 (IOS에서만 KeyboardAvoidingView 사용)
- [x] 모달에서 키보드가 열려있을 때, 배경을 클릭하면 모달은 유지되고 키보드만 닫히도록 수정
- [x] 일기 수동 작성 모달 퍼블리싱
- [x] 일기 없는 날짜 클릭 시, 수동 작성 모달이 열리도록 구현
- [x] 일기 수동 작성 Mutation API 연동
- [x] 테스트

## 📷스크린샷 / 영상

| Android | IOS |
|---------|-----|
| <video src='https://github.com/user-attachments/assets/137e576e-825d-4222-a20d-8d4cbc153f6d' /> | <video src='https://github.com/user-attachments/assets/1e95c3c5-7608-4cdf-bbd9-1439d6c63fc5' /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자가 일정 내 특정 날짜에서 직접 일기를 작성할 수 있는 수동 일기 작성 기능 추가
  * 일기 작성 시 제목, 내용, 해시태그 입력 지원
  * 모달 기반 사용자 인터페이스로 날짜별 일기 작성 경험 개선

* **Improvements**
  * iOS 기기에서 키보드 처리 최적화로 모달 접근성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->