### PR TITLE
[feat/melissa-1.3] 일기 이미지 비동기 polling 로직 추가

### DIFF
--- a/src/features/home/components/bottomSheet/DiaryBottomSheet.tsx
+++ b/src/features/home/components/bottomSheet/DiaryBottomSheet.tsx
@@ -1,4 +1,3 @@
-import { useGetCalendarView } from '@/src/apis/_generated/serverAPI';
 import { mergeRefs } from '@/src/utils/mergeRefs';
 import BottomSheet from '@gorhom/bottom-sheet';
 import { Portal } from '@gorhom/portal';
@@ -6,6 +5,7 @@ import { forwardRef, useRef, useState } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import styled from 'styled-components/native';
 import { useBottomSheetBackHandler } from '../../hooks/useBottomSheetBackHandler';
+import { useGetDiary } from '../../hooks/useGetDiary';
 import type { TDateData } from '../../types';
 import Backdrop from './Backdrop';
 import DiaryBottomSheetList from './DiaryBottomSheetList';
@@ -21,7 +21,7 @@ const DiaryBottomSheet = forwardRef<BottomSheet, Props>(({ date }, ref) => {
   const [width, setWidth] = useState<number | null>(null);
   const bottomSheetRef = useRef<BottomSheet>(null);
 
-  const { data: calendarMonthData } = useGetCalendarView({
+  const { data: calendarMonthData } = useGetDiary({
     year: date.year,
     month: date.month,
   });

--- a/src/features/home/components/bottomSheet/DiaryBottomSheetListItem.tsx
+++ b/src/features/home/components/bottomSheet/DiaryBottomSheetListItem.tsx
@@ -1,4 +1,5 @@
 import type { DiaryDetailDTO } from '@/src/apis/_generated/serverAPI.schemas';
+import PlaceholderImage from '@/src/core/PlaceholderImage';
 import { Body2, Description2, Title } from '@/src/core/Txt';
 import { IconShared } from '@/src/icons';
 import { Image } from 'expo-image';
@@ -13,7 +14,9 @@ type Props = {
 const DiaryBottomSheetListItem = ({ date, diaryData }: Props) => {
   return (
     <Wrapper>
-      <StyledImage source={{ uri: diaryData.imageUrl }} />
+      <ImageWrapper>
+        {diaryData.imageUrl ? <StyledImage source={{ uri: diaryData.imageUrl }} /> : <PlaceholderImage />}
+      </ImageWrapper>
       <RelativeWrapper>
         <ShareButton hitSlop={5}>
           <IconShared />
@@ -40,10 +43,15 @@ const Wrapper = styled.View`
   border-radius: 40px;
 `;
 
-const StyledImage = styled(Image)`
+const ImageWrapper = styled.View`
   width: 100%;
   aspect-ratio: 1;
   border-radius: 25px;
+  overflow: hidden;
+`;
+
+const StyledImage = styled(Image)`
+  flex: 1;
 `;
 
 const RelativeWrapper = styled.View`

--- a/src/features/home/components/calendar/CalendarDay.tsx
+++ b/src/features/home/components/calendar/CalendarDay.tsx
@@ -1,9 +1,9 @@
-import { useGetCalendarView } from '@/src/apis/_generated/serverAPI';
 import { COLOR } from '@/src/constants/theme';
 import { Description1 } from '@/src/core/Txt';
 import type { DateData } from 'react-native-calendars';
 import type { BasicDayProps } from 'react-native-calendars/src/calendar/day/basic';
 import styled from 'styled-components/native';
+import { useGetDiary } from '../../hooks/useGetDiary';
 import { getTodayDateData } from '../../utils/getTodayDateData';
 import { isCalendarDayData } from '../../utils/typeGuard';
 import CalendarDayContent from './CalendarDayContent';
@@ -15,7 +15,7 @@ type Props = Omit<BasicDayProps, 'date'> & {
 const CalendarDay = ({ date, onPress }: Props) => {
   const today = getTodayDateData();
 
-  const { data: calendarMonthData } = useGetCalendarView({
+  const { data: calendarMonthData } = useGetDiary({
     year: date?.year ?? today.year,
     month: date?.month ?? today.month,
   });

--- a/src/features/home/components/calendar/CalendarDayContent.tsx
+++ b/src/features/home/components/calendar/CalendarDayContent.tsx
@@ -1,4 +1,5 @@
 import { COLOR } from '@/src/constants/theme';
+import PlaceholderImage from '@/src/core/PlaceholderImage';
 import { Image } from 'expo-image';
 import styled from 'styled-components/native';
 import type { CalendarDayData } from '../../types';
@@ -12,13 +13,13 @@ const CalendarDayContent = ({ dayData }: Props) => {
   const imageUrl = dayData?.diaries.at(0)?.imageUrl;
   const hashtag = dayData?.diaries.at(0)?.hashtag1;
 
-  if (!imageUrl || !hashtag) {
+  if (!hashtag) {
     return <EmptyBox />;
   }
 
   return (
     <ImageBorderWrapper>
-      <StyledImage source={{ uri: imageUrl }} />
+      <ImageWrapper>{imageUrl ? <StyledImage source={{ uri: imageUrl }} /> : <PlaceholderImage />}</ImageWrapper>
       <HashtagBubble isVisible={!!dayData?.showBubble} hashtag={hashtag} />
     </ImageBorderWrapper>
   );
@@ -40,8 +41,13 @@ const ImageBorderWrapper = styled.View`
   border-radius: 19px;
 `;
 
-const StyledImage = styled(Image)`
+const ImageWrapper = styled.View`
   width: 100%;
   aspect-ratio: 1;
   border-radius: 15px;
+  overflow: hidden;
+`;
+
+const StyledImage = styled(Image)`
+  flex: 1;
 `;

--- a/src/features/home/components/feed/FeedDiaryListItem.tsx
+++ b/src/features/home/components/feed/FeedDiaryListItem.tsx
@@ -1,5 +1,6 @@
 import type { DiaryDetailDTO } from '@/src/apis/_generated/serverAPI.schemas';
 import { COLOR } from '@/src/constants/theme';
+import PlaceholderImage from '@/src/core/PlaceholderImage';
 import { Body2, Description2, Title } from '@/src/core/Txt';
 import { IconShared } from '@/src/icons';
 import { Image } from 'expo-image';
@@ -16,7 +17,9 @@ type Props = {
 const FeedDiaryListItem = ({ date, diaryData, onLayout }: Props) => {
   return (
     <Wrapper onLayout={onLayout}>
-      <StyledImage source={{ uri: diaryData.imageUrl }} />
+      <ImageWrapper>
+        {diaryData.imageUrl ? <StyledImage source={{ uri: diaryData.imageUrl }} /> : <PlaceholderImage />}
+      </ImageWrapper>
       <RelativeWrapper>
         <ShareButton hitSlop={5}>
           <IconShared />
@@ -46,10 +49,15 @@ const Wrapper = styled.View`
   background-color: ${COLOR.white};
 `;
 
-const StyledImage = styled(Image)`
+const ImageWrapper = styled.View`
   width: 100%;
   aspect-ratio: 1;
   border-radius: 25px;
+  overflow: hidden;
+`;
+
+const StyledImage = styled(Image)`
+  flex: 1;
 `;
 
 const RelativeWrapper = styled.View`

--- a/src/features/home/containers/FeedContainer.tsx
+++ b/src/features/home/containers/FeedContainer.tsx
@@ -1,10 +1,10 @@
-import { useGetCalendarView } from '@/src/apis/_generated/serverAPI';
 import { COLOR } from '@/src/constants/theme';
 import { getTodayDate } from '@/src/utils/date';
 import { useState } from 'react';
 import styled from 'styled-components/native';
 import FeedList from '../components/feed/FeedList';
 import HomeHeader from '../components/header/HomeHeader';
+import { useGetDiary } from '../hooks/useGetDiary';
 import { isNonNullableDailySummaryResponse } from '../utils/typeGuard';
 
 const FeedContainer = () => {
@@ -12,7 +12,7 @@ const FeedContainer = () => {
   const year = todayDate.year;
   const [month, setMonth] = useState<number>(todayDate.month);
 
-  const { data } = useGetCalendarView({ year, month });
+  const { data } = useGetDiary({ year, month });
   const calendarMonthData = data?.result?.filter(isNonNullableDailySummaryResponse);
 
   return (

--- a/src/features/home/hooks/useGetDiary.ts
+++ b/src/features/home/hooks/useGetDiary.ts
@@ -1,0 +1,23 @@
+import { useGetCalendarView } from '@/src/apis/_generated/serverAPI';
+import type {
+  ApiResponseListDailySummaryResponseDTO,
+  GetCalendarViewParams,
+} from '@/src/apis/_generated/serverAPI.schemas';
+import type { Query } from '@tanstack/react-query';
+
+export const useGetDiary = ({ year, month }: GetCalendarViewParams) => {
+  return useGetCalendarView(
+    { year, month },
+    {
+      query: { refetchInterval },
+    }
+  );
+};
+
+const refetchInterval = (query: Query<ApiResponseListDailySummaryResponseDTO>) => {
+  const result = query.state.data?.result;
+  if (!result) return 3000;
+
+  const isRefetch = result.some((data) => data?.diaries.some((diary) => !!diary.hashtag1 && !diary.imageUrl));
+  return isRefetch ? 2000 : false;
+};

--- a/src/features/home/hooks/useRandomizeHashtagBubble.ts
+++ b/src/features/home/hooks/useRandomizeHashtagBubble.ts
@@ -1,8 +1,9 @@
-import { getGetCalendarViewQueryKey, useGetCalendarView } from '@/src/apis/_generated/serverAPI';
+import { getGetCalendarViewQueryKey } from '@/src/apis/_generated/serverAPI';
 import type { ApiResponseListDailySummaryResponseDTO } from '@/src/apis/_generated/serverAPI.schemas';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 import { isNonNullableDailySummaryResponse } from '../utils/typeGuard';
+import { useGetDiary } from './useGetDiary';
 
 type Props = {
   year: number;
@@ -21,7 +22,7 @@ export const useRandomizeHashtagBubble = ({ year, month, intervalMs }: Props) =>
   const isEvenTurnRef = useRef<boolean>(true);
   const queryClient = useQueryClient();
 
-  const { data } = useGetCalendarView({ year, month });
+  const { data } = useGetDiary({ year, month });
 
   useEffect(() => {
     if (!data?.result) return;


### PR DESCRIPTION
## 👀 관련 이슈

close #192 

## ✨ 작업한 내용

- [x] 일기 데이터에서 이미지만 null인 데이터가 하나 이상 존재하면, 2초마다 refetch하는 로직 추가
- [x] `useGetCa`lendarView 사용처를 `useGetDiary` (`refetchInterval`이 적용된 `useGetCalendarView`)로 일괄 교체
- [x] 캘린더/피드/바텀 시트에서 `imageUrl`만 null이고, 나머지 데이터가 있는 경우 `placeholder` 이미지를 렌더링하도록 view 로직 수정

## 📷스크린샷 / 영상

| Android | IOS |
|---------|-----|
| <img width="300" alt="스크린샷 2025-12-15 23 19 05" src="https://github.com/user-attachments/assets/7ded3bea-cbcd-490d-8ead-118982303f30" /> | <img width="300" alt="스크린샷 2025-12-15 23 19 18" src="https://github.com/user-attachments/assets/3da5b442-9d28-486b-a5aa-baf8512ef288" /> |
| <img width="300" alt="스크린샷 2025-12-15 23 19 58" src="https://github.com/user-attachments/assets/03ebb2f8-f161-4333-993b-c280b87c7ae6" /> | <img width="300" alt="스크린샷 2025-12-15 23 20 10" src="https://github.com/user-attachments/assets/e2409655-9acc-41a7-a0f1-ee15676c8480" /> |
| <img width="300" alt="스크린샷 2025-12-15 23 21 44" src="https://github.com/user-attachments/assets/49b3e2be-97e5-45a7-9e2d-51d74ebf0999" /> | <img width="300" alt="스크린샷 2025-12-15 23 21 31" src="https://github.com/user-attachments/assets/b7536b9a-2128-47a2-8418-bbdb0c003bd4" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이미지 없는 다이어리 항목에 플레이스홀더 이미지 추가

* **버그 수정**
  * 캘린더 및 피드에서 이미지 렌더링 안정성 개선
  * 필수 데이터 없을 때 UI 충돌 방지

* **개선사항**
  * 다이어리 데이터 로딩 성능 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->