### PR TITLE
[main] Android 구글 플레이 콘솔 제출을 위해 이미지 저장소 권한 제거

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -25,6 +25,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       foregroundImage: './assets/images/adaptive-icon.png',
       backgroundColor: '#FFFFFF',
     },
+    blockedPermissions: ['android.permission.READ_MEDIA_IMAGES', 'android.permission.READ_MEDIA_VIDEO'],
     softwareKeyboardLayoutMode: 'pan',
     googleServicesFile: process.env.GOOGLE_SERVICES_JSON,
     package: 'com.melissa.melissaFE',


### PR DESCRIPTION
## 👀 관련 이슈

close #201 

([관련 Github issue](https://github.com/expo/expo/issues/37908#issuecomment-3057609427))

## ✨ 작업한 내용

- [x] `app.config.ts`의 `android.blockedPermissions`에 `android.permission.READ_MEDIA_IMAGES`, `android.permission.READ_MEDIA_VIDEO` 추가

## 📷스크린샷 / 영상

<img width="711" height="166" alt="스크린샷 2025-12-18 23 04 23" src="https://github.com/user-attachments/assets/e33aa1ab-8fc8-4fce-ae4a-f57fb825216f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Android 미디어 권한 설정 개선 - 이미지 및 비디오 읽기 권한 차단 옵션 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->