### PR TITLE
[main] 일기 스트릭 카운트 0으로 임시 교체

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -6,7 +6,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: 'Melissa',
   slug: 'melissa',
   owner: 'teammelissa7',
-  version: '1.3.0',
+  version: '1.3.1',
   orientation: 'portrait',
   icon: './assets/images/icon.png',
   scheme: 'myapp',

--- a/src/features/home/components/header/StreakBadge.tsx
+++ b/src/features/home/components/header/StreakBadge.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components/native';
 
 const StreakBadge = () => {
   //TODO: 스트릭 수 API 요청해서 응답 받아오기
-  const data = 1700;
+  const data = 0;
 
   return (
     <Wrapper>


### PR DESCRIPTION
## 👀 관련 이슈

예시: close #203 

## ✨ 작업한 내용

스트릭을 프론트에서 계산하는 것에 한계가 있어 (달 경계) 추후 백엔드 API 형태로 작업하고, 우선 0으로 교체합니다.

- [x] 스트릭 0으로 교체
- [x] 1.3.1 버전업