### PR TITLE
[main] 특정 상황에서 화면이 Freeze되는 이슈 대응

### DIFF
--- a/src/features/chatting/components/GenerateDiaryButton.tsx
+++ b/src/features/chatting/components/GenerateDiaryButton.tsx
@@ -1,19 +1,26 @@
 import { PrimaryButton } from '@/src/core/Button';
 import { IconCheck } from '@/src/icons';
 import responsiveToPx from '@/src/utils/responsiveToPx';
+import { ActivityIndicator } from 'react-native';
 import styled from 'styled-components/native';
 
 type Props = {
   isVisible: boolean;
+  isLoading?: boolean;
   disabled: boolean;
   onClick: () => void;
 };
 
-const GenerateDiaryButton = ({ isVisible, disabled, onClick }: Props) => {
+const GenerateDiaryButton = ({ isVisible, isLoading, disabled, onClick }: Props) => {
   if (!isVisible) return null;
 
   return (
-    <StyledPrimaryButton size="small" icon={<IconCheck />} disabled={disabled} onPress={onClick}>
+    <StyledPrimaryButton
+      size="small"
+      icon={isLoading ? <StyledLoadingIndicator /> : <IconCheck />}
+      disabled={disabled}
+      onPress={onClick}
+    >
       일기 쓰기
     </StyledPrimaryButton>
   );
@@ -25,4 +32,9 @@ const StyledPrimaryButton = styled(PrimaryButton)`
   position: absolute;
   right: 0;
   bottom: ${responsiveToPx('72px')};
+`;
+
+const StyledLoadingIndicator = styled(ActivityIndicator)`
+  width: 20px;
+  height: 20px;
 `;

--- a/src/features/chatting/containers/ChatContainer.tsx
+++ b/src/features/chatting/containers/ChatContainer.tsx
@@ -115,6 +115,7 @@ const ChatContainer = () => {
         <View>
           <GenerateDiaryButton
             isVisible={canGenerateDiary}
+            isLoading={generateDiaryMutation.isPending}
             disabled={generateDiaryMutation.isPending}
             onClick={handleDiarySummaryClick}
           />

--- a/src/features/chatting/containers/ChatContainer.tsx
+++ b/src/features/chatting/containers/ChatContainer.tsx
@@ -68,7 +68,7 @@ const ChatContainer = () => {
       },
       onSuccess: () => {
         toast({ message: '일기가 생성되었습니다.', options: { type: 'success' } });
-        router.navigate('/(app)/(tab)/calendar');
+        router.dismissAll();
       },
       onError: (e) => {
         if (e.response?.status === 429) {

--- a/src/libs/queryClient.ts
+++ b/src/libs/queryClient.ts
@@ -1,9 +1,4 @@
-import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
-import { router } from 'expo-router';
-import { toast } from '@/src/modules/toast';
-import toastMessage from '@/src/constants/toastMessage';
-import { removeRefreshToken } from '@/src/libs/secureStorage';
-import { removeAccessToken } from '@/src/libs/mmkv';
+import { QueryClient } from '@tanstack/react-query';
 
 export default new QueryClient({
   defaultOptions: {
@@ -12,37 +7,4 @@ export default new QueryClient({
       retry: 0,
     },
   },
-  queryCache: new QueryCache({
-    onError: async (error) => {
-      console.log('글로벌 query 에러');
-      if (error.response?.data) {
-        console.log(error.response.data);
-        const code = error.response.data.code;
-        if (code === 'AUTH4006') {
-          // 다른 기기에서 이미 삭제된 계정인 경우
-          await removeRefreshToken();
-          removeAccessToken();
-          toast({ message: toastMessage.accountNotFound, options: { type: 'error' } });
-          router.navigate('/login');
-        } else if (code !== '401') {
-          toast({ message: error.response?.data.message, options: { type: 'error' } });
-        }
-      }
-    },
-  }),
-  mutationCache: new MutationCache({
-    onError: async (error) => {
-      console.log('글로벌 mutation 에러');
-      if (error.response?.data) {
-        const code = error.response.data.code;
-        if (code === 'AUTH4006') {
-          // 다른 기기에서 이미 삭제된 계정인 경우
-          await removeRefreshToken();
-          removeAccessToken();
-          toast({ message: toastMessage.accountNotFound, options: { type: 'error' } });
-          router.navigate('/login');
-        }
-      }
-    },
-  }),
 });

--- a/src/modules/axios/interceptors/response.ts
+++ b/src/modules/axios/interceptors/response.ts
@@ -59,6 +59,7 @@ export const responseErrorInterceptor = async (error: AxiosError) => {
     removeAccessToken();
     await removeRefreshToken();
     rejectPendingApiQueue();
+    if (router.canDismiss()) router.dismissAll();
     router.replace('/login');
     return Promise.reject(error);
   } finally {

--- a/src/modules/axios/tests/axiosInstance.test.ts
+++ b/src/modules/axios/tests/axiosInstance.test.ts
@@ -11,6 +11,8 @@ let mockRefreshToken = 'valid-rt';
 
 jest.mock('expo-router', () => ({
   router: {
+    canDismiss: jest.fn(() => true),
+    dismissAll: jest.fn(),
     replace: jest.fn(),
   },
 }));
@@ -109,6 +111,7 @@ describe('access token 자동 재발급 테스트', () => {
       },
     });
 
+    expect(router.dismissAll).toHaveBeenCalled();
     expect(router.replace).toHaveBeenCalledWith('/login');
     expect(removeAccessToken).toHaveBeenCalled();
     expect(removeRefreshToken).toHaveBeenCalled();


### PR DESCRIPTION
## 👀 관련 이슈

expo-router의 `navigate`, `replace`, `back` 메서드가 혼용되어 라우팅 구조가 꼬이는 문제를 `dismissAll`을 활용해 해결했습니다.

추가로 일기 쓰기 버튼에 로딩 인디케이터를 추가했습니다.

#216 

## ✨ 작업한 내용

- [x] 라우팅 구조가 꼬이는 원인 상세 파악 (tabs의 캘린더가 있는데, 그 위에 stack 형태로 캘린더가 추가되는 문제)
- [x] 불필요해진 React Query의 global error handling 로직 제거
- [x] Axios interceptor에서 토큰 만료 시, 로그인 페이지로 redirect 전, 스택 초기화 처리
- [x] 토큰 재발급 테스트 코드에 `dismissAll` 모킹 추가
- [x] 일기 생성 성공 시, 캘린더로 `navigate` 하지 않고, `dismissAll`을 사용해 tabs를 제외한 모든 라우터 제거
- [x] 일기 생성 중일 때, 일기 생성 버튼에 로딩 스피너 추가


## 📷스크린샷 / 영상

| Android | IOS |
|---------|-----|
| <video width='300' src='https://github.com/user-attachments/assets/205dccc1-89b3-40b8-896d-a2a8b3a89879' /> | <video width='300' src='https://github.com/user-attachments/assets/99767810-25ca-4f32-a775-72c1005dc3e9' /> |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 다이어리 생성 중 로딩 상태 표시 추가

* **개선 사항**
  * 다이어리 생성 후 네비게이션 플로우 개선
  * 에러 처리 및 인증 흐름 최적화

* **테스트**
  * 라우팅 및 토큰 처리 테스트 케이스 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->