### PR TITLE
[main] 캐러셀 반응이 느린 문제 개선

### DIFF
--- a/src/features/characters/components/CharacterList.tsx
+++ b/src/features/characters/components/CharacterList.tsx
@@ -1,8 +1,10 @@
-import type { CharacterId } from '@/src/modules/character';
+import { COLOR } from '@/src/constants/theme';
+import { useCarousel } from '@/src/hooks/useCarousel';
+import { type CharacterId } from '@/src/modules/character';
 import responsiveToPx from '@/src/utils/responsiveToPx';
 import { useRef, useState } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
-import Carousel, { type ICarouselInstance } from 'react-native-reanimated-carousel';
+import Carousel, { Pagination, type ICarouselInstance } from 'react-native-reanimated-carousel';
 import styled from 'styled-components/native';
 import CarouselButton from './CarouselButton';
 import CharacterCard from './CharacterCard';
@@ -17,15 +19,13 @@ const CHARACTER_ID_LIST = [1, 2, 3, 4, 5] satisfies CharacterId[];
 const CharacterList = ({ selectedId, onSelectChange }: Props) => {
   const [width, setWidth] = useState<number | null>(null);
   const carouselRef = useRef<ICarouselInstance>(null);
+
+  const { progress, handleProgressChange } = useCarousel((index) => onSelectChange(CHARACTER_ID_LIST[index]));
   const disabledPrevButton = selectedId === 1;
   const disabledNextButton = selectedId === CHARACTER_ID_LIST.length;
 
   const getListWidth = (e: LayoutChangeEvent) => {
     setWidth(e.nativeEvent.layout.width);
-  };
-
-  const handleSnapToItem = (index: number) => {
-    onSelectChange(CHARACTER_ID_LIST[index]);
   };
 
   const handlePrevClick = () => {
@@ -51,10 +51,17 @@ const CharacterList = ({ selectedId, onSelectChange }: Props) => {
             parallaxScrollingScale: 1,
             parallaxScrollingOffset: 70,
           }}
-          onSnapToItem={handleSnapToItem}
+          onProgressChange={handleProgressChange}
           renderItem={({ item }) => <CharacterCard characterId={item} />}
         />
       )}
+      <Pagination.Basic
+        progress={progress}
+        data={CHARACTER_ID_LIST}
+        dotStyle={{ width: 8, height: 8, borderRadius: 4, backgroundColor: '#DDD' }}
+        activeDotStyle={{ backgroundColor: COLOR.main }}
+        containerStyle={{ gap: 6 }}
+      />
       <CarouselButton direction="left" disabled={disabledPrevButton} onClick={handlePrevClick} />
       <CarouselButton direction="right" disabled={disabledNextButton} onClick={handleNextClick} />
     </Container>
@@ -67,5 +74,6 @@ const Container = styled.View`
   position: relative;
   width: 100%;
   justify-content: center;
+  gap: 8px;
   height: ${responsiveToPx('366px')};
 `;

--- a/src/features/home/components/shareModal/ShareDiaryList.tsx
+++ b/src/features/home/components/shareModal/ShareDiaryList.tsx
@@ -1,8 +1,9 @@
 import type { DiaryDetailDTO } from '@/src/apis/_generated/serverAPI.schemas';
 import { COLOR } from '@/src/constants/theme';
-import { forwardRef, useState } from 'react';
+import { useCarousel } from '@/src/hooks/useCarousel';
+import { forwardRef } from 'react';
 import { useWindowDimensions, View } from 'react-native';
-import Carousel from 'react-native-reanimated-carousel';
+import Carousel, { Pagination } from 'react-native-reanimated-carousel';
 import styled from 'styled-components/native';
 import type { TDate } from '../../types';
 import ShareDiaryDetail from './ShareDiaryDetail';
@@ -13,11 +14,11 @@ type Props = {
   diaryData: Required<DiaryDetailDTO>;
 };
 
+const pages = [ShareDiaryThumbnail, ShareDiaryDetail];
+
 const ShareDiaryList = forwardRef<View, Props>(({ date, diaryData }, ref) => {
   const { width } = useWindowDimensions();
-  const [index, setIndex] = useState<number>(0);
-
-  const pages = [ShareDiaryThumbnail, ShareDiaryDetail];
+  const { progress, handleProgressChange } = useCarousel();
 
   return (
     <Wrapper>
@@ -27,16 +28,18 @@ const ShareDiaryList = forwardRef<View, Props>(({ date, diaryData }, ref) => {
           height={width}
           data={pages}
           loop={false}
-          onSnapToItem={setIndex}
+          onProgressChange={handleProgressChange}
           renderItem={({ item: Page }) => <Page date={date} diaryData={diaryData} />}
           onConfigurePanGesture={(gestureChain) => gestureChain.activeOffsetX([-10, 10])}
         />
       </View>
-      <Indicator>
-        {pages.map((_, idx) => (
-          <Dot key={idx} $active={idx === index} />
-        ))}
-      </Indicator>
+      <Pagination.Basic
+        progress={progress}
+        data={pages}
+        dotStyle={{ width: 8, height: 8, borderRadius: 4, backgroundColor: '#DDD' }}
+        activeDotStyle={{ backgroundColor: COLOR.main }}
+        containerStyle={{ gap: 6 }}
+      />
     </Wrapper>
   );
 });
@@ -47,18 +50,4 @@ export default ShareDiaryList;
 
 const Wrapper = styled.View`
   gap: 20px;
-`;
-
-const Indicator = styled.View`
-  flex-direction: row;
-  justify-content: center;
-  gap: 8px;
-  margin-top: 10px;
-`;
-
-const Dot = styled.View<{ $active: boolean }>`
-  width: 8px;
-  height: 8px;
-  border-radius: 4px;
-  background-color: ${({ $active }) => ($active ? COLOR.main : '#DDD')};
 `;

--- a/src/hooks/useCarousel.ts
+++ b/src/hooks/useCarousel.ts
@@ -1,0 +1,28 @@
+import { useSharedValue } from 'react-native-reanimated';
+
+/**
+ * @description
+ * 기본 캐러셀의 `onSnapToItem`은 애니메이션 종료 후 실행되어 반응이 느립니다.
+ * 이 훅은 `onProgressChange`의 `absoluteProgress`를 반올림하여 즉시 인덱스를 감지합니다.
+ *
+ * @param onCarouselIndexChange - 캐러셀 인덱스가 변경될 때 실행될 콜백 함수
+ *
+ * @returns progress - 현재 캐러셀의 진행도를 나타내는 `sharedValue`
+ * @returns handleProgressChange - 캐러셀의 `onProgressChange`에 전달할 핸들러
+ *
+ * @example
+ * absoluteProgress 반올림 동작:
+ * - progress = 0.4 → Math.round(0.4) = 0 → onCarouselIndexChange(0)
+ * - progress = 0.7 → Math.round(0.7) = 1 → onCarouselIndexChange(1)
+ * - progress = 1.5 → Math.round(1.5) = 2 → onCarouselIndexChange(2)
+ */
+export const useCarousel = (onCarouselIndexChange?: (index: number) => void) => {
+  const progress = useSharedValue<number>(0);
+
+  const handleProgressChange = (_: number, absoluteProgress: number) => {
+    progress.value = absoluteProgress;
+    onCarouselIndexChange?.(Math.round(absoluteProgress));
+  };
+
+  return { progress, handleProgressChange };
+};


### PR DESCRIPTION
## 👀 관련 이슈

close #219 

## ✨ 작업한 내용

- [x] sharedValue인 `progress`를 반올림해서 현재 index를 계산해 callback을 실행하는 `useCarousel` 커스텀 훅 구현
- [x] 캐릭터 선택 페이지에 useCarousel 훅 적용하고, Pagination 컴포넌트 추가
- [x] 공유 모달에 useCarousel 훅 적용하고, Pagination 컴포넌트에 progress를 넘겨 애니메이션 개선

## 📷스크린샷 / 영상

| 작업 전 | 작업 후 |
|-------|--------|
| <video src='https://github.com/user-attachments/assets/960c4b11-f598-46b9-808e-a5acd4a4a5dc' /> | <video src='https://github.com/user-attachments/assets/784cd403-5697-4f6a-9db5-eaf4f92fb1a6' /> |
| <video src='https://github.com/user-attachments/assets/8ddae5da-f89f-4028-b80e-19e426eb50ff' /> | <video src='https://github.com/user-attachments/assets/1514c316-5554-4d59-a420-57c6dba5055f' /> | 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캐러셀에 향상된 페이지네이션 지원이 추가되었습니다. 진행 표시기가 이제 선택된 항목과 동기화되어 더 직관적인 네비게이션을 제공합니다.
  * 캐러셀 진행 상태 관리가 개선되어 더욱 부드러운 사용자 경험을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->