### PR TITLE
[main] 일기 스트릭 API 연동

### DIFF
--- a/src/features/chatting/containers/ChatContainer.tsx
+++ b/src/features/chatting/containers/ChatContainer.tsx
@@ -1,5 +1,6 @@
 import {
   getGetCalendarViewQueryKey,
+  getGetCurrentStreakQueryKey,
   getGetMessagesQueryKey,
   useCreateChatDiary,
   useGetMessages,
@@ -63,6 +64,7 @@ const ChatContainer = () => {
     mutation: {
       onSettled: () => {
         queryClient.invalidateQueries({ queryKey: getGetCalendarViewQueryKey({ year, month }) });
+        queryClient.invalidateQueries({ queryKey: getGetCurrentStreakQueryKey() });
       },
       onSuccess: () => {
         toast({ message: '일기가 생성되었습니다.', options: { type: 'success' } });

--- a/src/features/home/components/header/StreakBadge.tsx
+++ b/src/features/home/components/header/StreakBadge.tsx
@@ -1,16 +1,18 @@
+import { useGetCurrentStreak } from '@/src/apis/_generated/serverAPI';
 import { COLOR } from '@/src/constants/theme';
 import { Label } from '@/src/core/Txt';
 import { IconCharacter } from '@/src/icons';
+import { ActivityIndicator } from 'react-native';
 import styled from 'styled-components/native';
 
 const StreakBadge = () => {
-  //TODO: 스트릭 수 API 요청해서 응답 받아오기
-  const data = 0;
+  const { isPending, data: streakData } = useGetCurrentStreak();
+  const streak = streakData?.result?.streakDays ?? 0;
 
   return (
     <Wrapper>
       <StyledIconCharacter />
-      <Label color="title">{data.toLocaleString()}</Label>
+      {isPending ? <ActivityIndicator /> : <Label color="title">{streak.toLocaleString()}</Label>}
     </Wrapper>
   );
 };


### PR DESCRIPTION
## 👀 관련 이슈

close #222 

#215 #218 작업을 포함해서 1.3.2로 빌드 배포합니다.

## ✨ 작업한 내용

- [x] 스트릭 조회 API 연동
- [x] 일기 요약 성공 시 스트릭 query 무효화