### PR TITLE
[main] 일기 수동 작성 기능 구현

### DIFF
--- a/src/app/(app)/write-diary.tsx
+++ b/src/app/(app)/write-diary.tsx
@@ -1,6 +1,8 @@
+import WriteDiaryContainer from '@/src/features/write-diary/containers/WriteDiaryContainer';
+
 /**
  * @description 수동 일기 작성 페이지 라우터
  */
 export default function WriteDiaryRouter() {
-  return null;
+  return <WriteDiaryContainer />;
 }

--- a/src/app/(app)/write-diary.tsx
+++ b/src/app/(app)/write-diary.tsx
@@ -1,0 +1,6 @@
+/**
+ * @description 수동 일기 작성 페이지 라우터
+ */
+export default function WriteDiaryRouter() {
+  return null;
+}

--- a/src/features/characters/containers/CharactersContainer.tsx
+++ b/src/features/characters/containers/CharactersContainer.tsx
@@ -5,7 +5,6 @@ import type { CharacterId } from '@/src/modules/character';
 import { toast } from '@/src/modules/toast';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
-import { Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import styled from 'styled-components/native';
 import ActionButtons from '../components/ActionButtons';
@@ -43,7 +42,7 @@ const CharactersContainer = () => {
   };
 
   const handleManualDiaryClick = () => {
-    Alert.alert('준비중인 기능입니다.');
+    router.navigate(`/(app)/write-diary?year=${year}&month=${month}&day=${day}`);
   };
 
   return (

--- a/src/features/home/components/bottomSheet/DiaryBottomSheetListItem.tsx
+++ b/src/features/home/components/bottomSheet/DiaryBottomSheetListItem.tsx
@@ -40,7 +40,9 @@ const DiaryBottomSheetListItem = ({ date, diaryData }: Props) => {
         <StyledHashtagTxt color="main">
           #{diaryData.hashtag1} #{diaryData.hashtag2}
         </StyledHashtagTxt>
-        <DiaryCreatedByInfo aiProfileId={diaryData.aiProfileId} createdAt={diaryData.createdAt} />
+        {diaryData.type === 'CHAT_BASED' && (
+          <DiaryCreatedByInfo aiProfileId={diaryData.aiProfileId} createdAt={diaryData.createdAt} />
+        )}
       </RelativeWrapper>
     </Wrapper>
   );

--- a/src/features/home/components/feed/FeedDiaryListItem.tsx
+++ b/src/features/home/components/feed/FeedDiaryListItem.tsx
@@ -43,7 +43,9 @@ const FeedDiaryListItem = ({ date, diaryData, onLayout }: Props) => {
         <StyledHashtagTxt color="main">
           #{diaryData.hashtag1} #{diaryData.hashtag2}
         </StyledHashtagTxt>
-        <DiaryCreatedByInfo aiProfileId={diaryData.aiProfileId} createdAt={diaryData.createdAt} />
+        {diaryData.type === 'CHAT_BASED' && (
+          <DiaryCreatedByInfo aiProfileId={diaryData.aiProfileId} createdAt={diaryData.createdAt} />
+        )}
       </RelativeWrapper>
     </Wrapper>
   );

--- a/src/features/write-diary/components/DiaryContentInput.tsx
+++ b/src/features/write-diary/components/DiaryContentInput.tsx
@@ -1,0 +1,33 @@
+import { COLOR, FONT_FAMILY } from '@/src/constants/theme';
+import styled from 'styled-components/native';
+
+type Props = {
+  value: string;
+  onValueChange: (value: string) => void;
+};
+
+const DiaryContentInput = ({ value, onValueChange }: Props) => {
+  return (
+    <StyledTextInput
+      value={value}
+      onChangeText={onValueChange}
+      multiline
+      textAlignVertical="top"
+      placeholder="내용을 작성해주세요."
+      placeholderTextColor={COLOR.placeholder}
+    />
+  );
+};
+
+export default DiaryContentInput;
+
+const StyledTextInput = styled.TextInput`
+  flex: 1;
+  padding: 16px 20px;
+  max-height: 350px;
+  background-color: ${COLOR.white};
+  border-radius: 20px;
+  font-family: ${FONT_FAMILY.pretendard500};
+  font-size: 14px;
+  color: ${COLOR.title};
+`;

--- a/src/features/write-diary/components/DiaryTitleInput.tsx
+++ b/src/features/write-diary/components/DiaryTitleInput.tsx
@@ -1,0 +1,30 @@
+import { COLOR, FONT_FAMILY } from '@/src/constants/theme';
+import styled from 'styled-components/native';
+
+type Props = {
+  value: string;
+  onValueChange: (value: string) => void;
+};
+
+const DiaryTitleInput = ({ value, onValueChange }: Props) => {
+  return (
+    <StyledTextInput
+      value={value}
+      onChangeText={onValueChange}
+      placeholder="제목을 작성해주세요."
+      placeholderTextColor={COLOR.placeholder}
+      maxLength={50}
+    />
+  );
+};
+
+export default DiaryTitleInput;
+
+const StyledTextInput = styled.TextInput`
+  padding: 16px 20px;
+  background-color: ${COLOR.white};
+  border-radius: 20px;
+  font-family: ${FONT_FAMILY.pretendard500};
+  font-size: 14px;
+  color: ${COLOR.title};
+`;

--- a/src/features/write-diary/components/WriteDiaryHeader.tsx
+++ b/src/features/write-diary/components/WriteDiaryHeader.tsx
@@ -1,0 +1,45 @@
+import { LargeTitle } from '@/src/core/Txt';
+import { IconArrowDown } from '@/src/icons';
+import responsiveToPx from '@/src/utils/responsiveToPx';
+import type { ReactNode } from 'react';
+import { TouchableOpacity } from 'react-native';
+import styled from 'styled-components/native';
+
+type Props = {
+  children: ReactNode;
+  onBackClick: () => void;
+};
+
+const WriteDiaryHeader = ({ children, onBackClick }: Props) => {
+  return (
+    <Wrapper>
+      <TouchableOpacity onPress={onBackClick} hitSlop={5}>
+        <StyledIconArrowLeft width={30} height={30} />
+      </TouchableOpacity>
+      <LargeTitle color="title">{children}</LargeTitle>
+      <EmptyView />
+    </Wrapper>
+  );
+};
+
+export default WriteDiaryHeader;
+
+const Wrapper = styled.View`
+  flex-direction: row;
+  width: 100%;
+  padding: 15px 0;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+`;
+
+const StyledIconArrowLeft = styled(IconArrowDown)`
+  width: ${responsiveToPx('30px')};
+  height: ${responsiveToPx('30px')};
+  transform: rotate(90deg);
+`;
+
+const EmptyView = styled.View`
+  width: ${responsiveToPx('30px')};
+  height: ${responsiveToPx('30px')};
+`;

--- a/src/features/write-diary/containers/WriteDiaryContainer.tsx
+++ b/src/features/write-diary/containers/WriteDiaryContainer.tsx
@@ -1,0 +1,65 @@
+import { COLOR } from '@/src/constants/theme';
+import { PrimaryButton } from '@/src/core/Button';
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+import { Keyboard, TouchableWithoutFeedback } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import styled from 'styled-components/native';
+import DiaryContentInput from '../components/DiaryContentInput';
+import DiaryTitleInput from '../components/DiaryTitleInput';
+import WriteDiaryHeader from '../components/WriteDiaryHeader';
+import { useWriteDiaryQueryParams } from '../hooks/useWriteDiaryQueryParams';
+
+const WriteDiaryContainer = () => {
+  const router = useRouter();
+  const { year, month, day } = useWriteDiaryQueryParams();
+  const [title, setTitle] = useState<string>('');
+  const [content, setContent] = useState<string>('');
+
+  const isFormValid = title.trim() && content.trim();
+
+  const handleBackClick = () => {
+    router.back();
+  };
+
+  const handleSubmit = () => {
+    if (!isFormValid) return;
+    // TODO: API 연결
+    console.log({ title, content, year, month, day });
+  };
+
+  return (
+    <SafeView>
+      <WriteDiaryHeader onBackClick={handleBackClick}>{`${year}년 ${month}월 ${day}일`}</WriteDiaryHeader>
+      <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
+        <ContentWrapper>
+          <DiaryTitleInput value={title} onValueChange={setTitle} />
+          <DiaryContentInput value={content} onValueChange={setContent} />
+        </ContentWrapper>
+      </TouchableWithoutFeedback>
+      <ButtonWrapper>
+        <PrimaryButton size="large" disabled={!isFormValid} onPress={handleSubmit}>
+          일기 저장하기
+        </PrimaryButton>
+      </ButtonWrapper>
+    </SafeView>
+  );
+};
+
+export default WriteDiaryContainer;
+
+const SafeView = styled(SafeAreaView)`
+  flex: 1;
+  background-color: ${COLOR.background};
+  padding: 0 18px;
+`;
+
+const ContentWrapper = styled.View`
+  flex: 1;
+  gap: 12px;
+`;
+
+const ButtonWrapper = styled.View`
+  margin: 0 auto;
+  padding-bottom: 20px;
+`;

--- a/src/features/write-diary/containers/WriteDiaryContainer.tsx
+++ b/src/features/write-diary/containers/WriteDiaryContainer.tsx
@@ -1,5 +1,13 @@
+import {
+  getGetCalendarViewQueryKey,
+  getGetCurrentStreakQueryKey,
+  getGetFeedQueryKey,
+  useCreateManualDiary,
+} from '@/src/apis/_generated/serverAPI';
 import { COLOR } from '@/src/constants/theme';
 import { PrimaryButton } from '@/src/core/Button';
+import { toast } from '@/src/modules/toast';
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import { Keyboard, TouchableWithoutFeedback } from 'react-native';
@@ -12,20 +20,35 @@ import { useWriteDiaryQueryParams } from '../hooks/useWriteDiaryQueryParams';
 
 const WriteDiaryContainer = () => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { year, month, day } = useWriteDiaryQueryParams();
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');
 
   const isFormValid = title.trim() && content.trim();
 
+  const createManualDiaryMutation = useCreateManualDiary({
+    mutation: {
+      onError: () => {
+        toast({ message: '저장에 실패했습니다. 잠시 후 다시 시도해주세요.', options: { type: 'error' } });
+      },
+      onSuccess: () => {
+        toast({ message: '저장되었습니다.', options: { type: 'success' } });
+        queryClient.invalidateQueries({ queryKey: getGetCalendarViewQueryKey({ year, month }) });
+        queryClient.invalidateQueries({ queryKey: getGetFeedQueryKey() });
+        queryClient.invalidateQueries({ queryKey: getGetCurrentStreakQueryKey() });
+      },
+    },
+  });
+
   const handleBackClick = () => {
     router.back();
   };
 
   const handleSubmit = () => {
-    if (!isFormValid) return;
-    // TODO: API 연결
-    console.log({ title, content, year, month, day });
+    if (!isFormValid || createManualDiaryMutation.isPending) return;
+    // TODO: aiProfileId 어떻게 할지 논의 필요
+    createManualDiaryMutation.mutate({ data: { aiProfileId: 0, year, month, day, title, content } });
   };
 
   return (

--- a/src/features/write-diary/containers/WriteDiaryContainer.tsx
+++ b/src/features/write-diary/containers/WriteDiaryContainer.tsx
@@ -47,8 +47,7 @@ const WriteDiaryContainer = () => {
 
   const handleSubmit = () => {
     if (!isFormValid || createManualDiaryMutation.isPending) return;
-    // TODO: aiProfileId 어떻게 할지 논의 필요
-    createManualDiaryMutation.mutate({ data: { aiProfileId: 0, year, month, day, title, content } });
+    createManualDiaryMutation.mutate({ data: { aiProfileId: 1, year, month, day, title, content } });
   };
 
   return (

--- a/src/features/write-diary/containers/WriteDiaryContainer.tsx
+++ b/src/features/write-diary/containers/WriteDiaryContainer.tsx
@@ -37,6 +37,7 @@ const WriteDiaryContainer = () => {
         queryClient.invalidateQueries({ queryKey: getGetCalendarViewQueryKey({ year, month }) });
         queryClient.invalidateQueries({ queryKey: getGetFeedQueryKey() });
         queryClient.invalidateQueries({ queryKey: getGetCurrentStreakQueryKey() });
+        router.dismissAll();
       },
     },
   });

--- a/src/features/write-diary/hooks/useWriteDiaryQueryParams.ts
+++ b/src/features/write-diary/hooks/useWriteDiaryQueryParams.ts
@@ -1,0 +1,25 @@
+import { useLocalSearchParams } from 'expo-router';
+
+type Params = {
+  year?: string;
+  month?: string;
+  day?: string;
+};
+
+export const useWriteDiaryQueryParams = () => {
+  const params = useLocalSearchParams<Params>();
+
+  if (!params || !params.year || !params.month || !params.day) {
+    throw new Error('쿼리 파라미터 year, month, day를 전달했는지 확인해주세요.');
+  }
+
+  const year = Number(params.year);
+  const month = Number(params.month);
+  const day = Number(params.day);
+
+  if (isNaN(year) || isNaN(month) || isNaN(day)) {
+    throw new Error('쿼리 파라미터 year, month, day가 숫자인지 확인해주세요.');
+  }
+
+  return { year, month, day };
+};


### PR DESCRIPTION
## 👀 관련 이슈

close #233 

## ✨ 작업한 내용

- [x] 개발 환경 이슈 대응
- [x] 일기 수동 작성 페이지 퍼블리싱
- [x] 일기 수동 작성 Mutation 연동
  - [x] aiProfileId 어떻게 처리할지 논의중 -> 1로 고정해서 날리고, 일기 데이터의 type 필드를 통해 구분하기로 결정 
- [x] 캘린더, 바텀시트, 피드에서 type이 MANUAL 이면, 수동 작성된 일기로 분기해 렌더링하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 날짜별 일기 작성 기능을 추가했습니다. 캐릭터 화면에서 직접 일기 작성 화면으로 이동할 수 있으며, 제목과 내용을 입력하여 저장할 수 있습니다.

## 개선 사항
* AI 기반 생성 일기와 수동 작성 일기를 구분하여 생성 정보를 선택적으로 표시하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->