### PR TITLE
[deploy/1.3.3] 일기 수정 / 삭제 기능 구현, 일기 수동 작성 페이지 UX 개선

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -6,7 +6,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: 'Melissa',
   slug: 'melissa',
   owner: 'teammelissa7',
-  version: '1.3.2',
+  version: '1.3.3',
   orientation: 'portrait',
   icon: './assets/images/icon.png',
   scheme: 'myapp',

--- a/docs/diary-edit-delete-spec.md
+++ b/docs/diary-edit-delete-spec.md
@@ -1,0 +1,522 @@
+# 일기 수정/삭제 기능 스펙 문서
+
+## 개요
+
+백엔드에 구현되어 있는 일기 수정/삭제 Mutation을 연동합니다.
+
+**구현 디렉토리**: `src/features/write-diary`
+
+---
+
+## 1. 기능 요구사항
+
+### 1.1 일기 수동 작성 페이지 UX 개선
+
+**문제**: 키보드가 올라오면 저장 버튼을 찾기 어려움
+
+**해결 방안**:
+
+- `react-native-keyboard-controller` 활용하여 키보드 위에 저장 버튼이 보이도록 처리
+- `ScrollView` 도입: Textarea + 해시태그 입력 영역이 커지므로 스크롤 가능하게 처리
+- 키보드 dismiss 시 원래 위치로 복귀
+
+**수용 조건**:
+
+- [ ] 키보드가 올라와도 저장 버튼이 화면에 보여야 함
+- [ ] 저장 버튼 클릭이 가능해야 함
+- [ ] 키보드 dismiss 시 레이아웃이 자연스럽게 복귀해야 함
+- [ ] 전체 폼 영역이 스크롤 가능해야 함
+
+---
+
+### 1.2 바텀시트/피드에 드롭다운 추가
+
+**설명**: 일기 상세 화면(바텀시트) 또는 피드에서 수정/삭제 버튼 접근
+
+**구현 내용**:
+
+- `src/core/Dropdown` 컴파운드 컴포넌트 활용
+- 메뉴 항목: "수정", "삭제"
+- 수정 클릭 시: 일기 수정 페이지로 이동
+- 삭제 클릭 시: 삭제 확인 모달 표시 후 삭제 API 호출
+
+**Dropdown 컴포넌트 사용 예시**:
+
+```tsx
+import { Dropdown } from '@/src/core/Dropdown';
+import { Txt } from '@/src/core/Txt';
+
+const DiaryOptionsDropdown = ({ diaryId, year, month, day, onDeletePress }) => {
+  const router = useRouter();
+
+  const handleEdit = () => {
+    // Tabs 내부에서 라우팅 시 navigate 사용 주의 (런타임 에러 가능)
+    router.navigate(`/edit-diary?diaryId=${diaryId}&year=${year}&month=${month}&day=${day}`);
+  };
+
+  return (
+    <Dropdown>
+      <Dropdown.Trigger />
+      {/* Trigger의 children이 없으면 기본 IconEllipsis(점 3개) 아이콘 렌더링 */}
+      <Dropdown.Menu align="end">
+        <Dropdown.Item onPress={handleEdit}>
+          <Txt>수정</Txt>
+        </Dropdown.Item>
+        <Dropdown.Item onPress={onDeletePress}>
+          <Txt>삭제</Txt>
+        </Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+};
+```
+
+**삭제 모달 구조** (`useModal` 훅 활용):
+
+```tsx
+// Container 레벨에서 모달 열기 함수 정의
+const deleteModal = useModal();
+const deleteMutation = useDeleteDiary({ ... });
+
+const handleDeletePress = () => {
+  deleteModal.open((close) => (
+    <DeleteConfirmModal
+      onCancel={close}
+      onConfirm={() => {
+        deleteMutation.mutate({ diaryId });
+        close();
+      }}
+    />
+  ));
+};
+
+// Dropdown의 onDeletePress props로 handleDeletePress 전달
+<DiaryOptionsDropdown onDeletePress={handleDeletePress} ... />
+```
+
+**수용 조건**:
+
+- [ ] 드롭다운 트리거 버튼(점 3개 아이콘)이 표시되어야 함
+- [ ] 드롭다운 클릭 시 메뉴가 표시되어야 함
+- [ ] 수정 클릭 시 `/edit-diary?diaryId={id}&year={y}&month={m}&day={d}` 로 이동
+- [ ] 삭제 클릭 시 확인 모달이 표시되어야 함
+
+---
+
+### 1.3 해시태그 Input 컴포넌트 구현
+
+**설명**: 일기 수정 시 해시태그를 입력받는 단일 필드 컴포넌트
+
+**API 스펙** (`DiaryUpdateRequest`):
+
+```typescript
+hashtag1?: string | null;  // 예: "#수정"
+hashtag2?: string | null;  // 예: "#일기"
+```
+
+**구현 내용**:
+
+- **단일 해시태그 입력 필드 컴포넌트** (컨테이너에서 2개 렌더링)
+- `#` 포함 최대 5글자 제한
+- 빈 문자열은 `null`로 처리
+- `#` prefix 자동 추가 또는 입력 시 포함 여부 결정
+
+**컴포넌트 사용 예시**:
+
+```tsx
+// EditDiaryContainer에서 2개 렌더링
+<DiaryHashtagInput
+  value={hashtag1}
+  onValueChange={setHashtag1}
+  placeholder="#태그1"
+/>
+<DiaryHashtagInput
+  value={hashtag2}
+  onValueChange={setHashtag2}
+  placeholder="#태그2"
+/>
+```
+
+**수용 조건**:
+
+- [ ] 단일 해시태그 입력 필드가 렌더링되어야 함
+- [ ] `#` 포함 5자 이하로 제한되어야 함
+- [ ] 입력값 변경 시 `onValueChange` 콜백이 호출되어야 함
+- [ ] placeholder가 표시되어야 함
+
+---
+
+### 1.4 일기 수정 페이지 (별도 라우터/컨테이너 분리)
+
+**설명**: 일기 수정 전용 페이지. 기존 일기 데이터를 불러와 폼에 채움
+
+**라우팅**: `src/app/(app)/edit-diary.tsx`
+
+**쿼리 파라미터** (모두 필수):
+
+- `diaryId`: 수정할 일기의 ID
+- `year`, `month`, `day`: 날짜 정보
+
+**데이터 로드 방식**:
+
+1. `useGetDailySummary({ year, month, day })` 호출
+2. 응답의 `diaries` 배열에서 `diaryId`로 해당 일기 찾기
+3. 찾은 데이터로 폼 초기값 설정
+
+**구현 내용**:
+
+1. 별도의 `EditDiaryContainer` 생성 (WriteDiaryContainer와 분리)
+2. 별도의 `useEditDiaryQueryParams` 훅 생성 (diaryId 필수 파라미터로 처리)
+3. 컴포넌트는 재사용: `DiaryTitleInput`, `DiaryContentInput`, `WriteDiaryHeader`
+4. 해시태그 Input 컴포넌트 2개 렌더링
+5. "저장" 버튼 클릭 시 `useUpdateDiary` mutation 호출
+6. **저장 성공 시**: 캘린더/피드/스트릭 쿼리 무효화 후 `router.dismissAll()`
+
+**수용 조건**:
+
+- [ ] `diaryId` 파라미터가 없으면 에러 처리되어야 함
+- [ ] 기존 데이터가 폼에 채워져야 함
+- [ ] 해시태그 Input 2개가 표시되어야 함
+- [ ] 저장 시 `updateDiary` API가 호출되어야 함
+- [ ] 수정 성공 시 쿼리 무효화 및 `dismissAll()` 호출
+
+---
+
+### 1.5 일기 삭제 Mutation 연동
+
+**API 스펙**:
+
+```typescript
+useDeleteDiary(diaryId: number)
+
+// Response
+DiaryDeleteResponse = {
+  diaryId: number;
+  message: string;
+} | null
+```
+
+**구현 내용**:
+
+- 삭제 확인 모달 표시 (useModal 훅 활용)
+- 확인 시 `useDeleteDiary` mutation 호출
+- 성공 시: 캘린더/피드/스트릭 쿼리 무효화, 바텀시트 닫기, 토스트 표시
+- 실패 시: 에러 토스트 표시
+
+**쿼리 무효화 대상**:
+
+```typescript
+queryClient.invalidateQueries({ queryKey: getGetCalendarViewQueryKey({ year, month }) });
+queryClient.invalidateQueries({ queryKey: getGetFeedQueryKey() });
+queryClient.invalidateQueries({ queryKey: getGetCurrentStreakQueryKey() });
+```
+
+**수용 조건**:
+
+- [ ] 삭제 확인 모달이 표시되어야 함
+- [ ] 확인 버튼 클릭 시 `deleteDiary` API가 호출되어야 함
+- [ ] 삭제 성공 시 관련 쿼리가 무효화되어야 함
+- [ ] 삭제 성공 시 바텀시트가 닫혀야 함
+- [ ] 성공/실패 시 적절한 토스트 메시지가 표시되어야 함
+
+---
+
+## 2. API 인터페이스
+
+### 2.0 일기 상세 조회 API (기존 데이터 로드용)
+
+```typescript
+// Hook
+useGetDailySummary(params: GetDailySummaryParams, options?: { ... })
+
+// Params
+{
+  year: number;
+  month: number;
+  day: number;
+}
+
+// Response: DailySummaryResponseDTO
+{
+  year: number;
+  month: number;
+  day: number;
+  diaries: DiaryDetailDTO[];  // 최대 3개
+}
+
+// DiaryDetailDTO (수정 폼 초기값으로 사용)
+{
+  diaryId: number;
+  aiProfileId: number;
+  title?: string | null;
+  content?: string | null;
+  mood?: 'HAPPY' | 'SAD' | 'TIRED' | 'ANGRY' | 'RELAX' | null;
+  type: 'MANUAL' | 'CHAT_BASED';
+  hashtag1?: string | null;
+  hashtag2?: string | null;
+  imageUrl?: string | null;
+  imageStatus?: 'NONE' | 'PENDING' | 'READY' | 'FAILED' | null;
+  version: number;
+  createdAt: string;
+}
+```
+
+### 2.1 일기 수정 API
+
+```typescript
+// Hook
+useUpdateDiary(options?: {
+  mutation?: UseMutationOptions;
+  request?: AxiosRequestConfig;
+})
+
+// 호출
+mutation.mutate({
+  diaryId: number,
+  data: DiaryUpdateRequest
+})
+
+// DiaryUpdateRequest
+{
+  title?: string | null;       // 0-100자
+  content?: string | null;     // 0-3000자
+  mood?: 'HAPPY' | 'SAD' | 'TIRED' | 'ANGRY' | 'RELAX' | null;
+  hashtag1?: string | null;    // # 포함 5자 (클라이언트 제한)
+  hashtag2?: string | null;    // # 포함 5자 (클라이언트 제한)
+  generateImage?: boolean;     // 이미지 재생성 여부 (기본값 false)
+}
+```
+
+### 2.2 일기 삭제 API
+
+```typescript
+// Hook
+useDeleteDiary(options?: {
+  mutation?: UseMutationOptions;
+  request?: AxiosRequestConfig;
+})
+
+// 호출
+mutation.mutate({ diaryId: number })
+
+// Response
+DiaryDeleteResponse = {
+  diaryId: number;
+  message: string;
+} | null
+```
+
+---
+
+## 3. TDD 테스트 계획
+
+TDD(테스트 주도 개발) 사이클을 엄격히 적용합니다:
+
+1. **Red**: 실패하는 테스트 작성
+2. **Green**: 테스트를 통과하는 최소한의 코드 구현
+3. **Refactor**: 코드 품질 개선
+
+### 3.1 테스트 파일 구조
+
+```
+src/features/write-diary/
+├── __tests__/
+│   ├── useWriteDiaryQueryParams.test.ts
+│   ├── useEditDiaryQueryParams.test.ts      # 신규
+│   ├── DiaryHashtagInput.test.tsx           # 신규
+│   └── EditDiaryContainer.test.tsx          # 신규
+├── components/
+│   ├── DiaryTitleInput.tsx
+│   ├── DiaryContentInput.tsx
+│   ├── DiaryHashtagInput.tsx                # 신규
+│   └── WriteDiaryHeader.tsx
+├── containers/
+│   ├── WriteDiaryContainer.tsx
+│   └── EditDiaryContainer.tsx               # 신규
+└── hooks/
+    ├── useWriteDiaryQueryParams.ts
+    └── useEditDiaryQueryParams.ts           # 신규
+```
+
+### 3.2 테스트 케이스
+
+#### 3.2.1 `useEditDiaryQueryParams` (신규)
+
+```typescript
+describe('useEditDiaryQueryParams', () => {
+  it('diaryId, year, month, day를 숫자로 변환하여 반환해야 함', () => {});
+  it('diaryId가 없으면 에러를 throw해야 함', () => {});
+  it('year, month, day 중 하나라도 없으면 에러를 throw해야 함', () => {});
+  it('파라미터가 숫자가 아니면 에러를 throw해야 함', () => {});
+});
+```
+
+#### 3.2.2 `DiaryHashtagInput` (신규)
+
+```typescript
+describe('DiaryHashtagInput', () => {
+  it('해시태그 입력 필드가 렌더링되어야 함', () => {});
+  it('입력값 변경 시 onValueChange가 호출되어야 함', () => {});
+  it('# 포함 5자 이하로 제한되어야 함', () => {});
+  it('placeholder가 올바르게 표시되어야 함', () => {});
+  it('초기값이 올바르게 설정되어야 함', () => {});
+});
+```
+
+#### 3.2.3 `EditDiaryContainer` (신규)
+
+```typescript
+describe('EditDiaryContainer', () => {
+  it('로딩 중일 때 로딩 UI가 표시되어야 함', () => {});
+  it('기존 일기 데이터로 폼이 채워져야 함', () => {});
+  it('해시태그 입력 필드 2개가 렌더링되어야 함', () => {});
+  it('저장 시 updateDiary가 호출되어야 함', () => {});
+  it('저장 성공 시 토스트가 표시되어야 함', () => {});
+  it('저장 성공 시 dismissAll이 호출되어야 함', () => {});
+});
+```
+
+#### 3.2.4 일기 삭제 테스트
+
+```typescript
+describe('useDeleteDiaryMutation', () => {
+  it('삭제 성공 시 관련 쿼리가 무효화되어야 함', () => {});
+  it('삭제 성공 시 성공 토스트가 표시되어야 함', () => {});
+  it('삭제 실패 시 에러 토스트가 표시되어야 함', () => {});
+});
+
+describe('DeleteConfirmModal', () => {
+  it('모달이 열리면 확인 메시지가 표시되어야 함', () => {});
+  it('취소 버튼 클릭 시 모달이 닫혀야 함', () => {});
+  it('확인 버튼 클릭 시 삭제 mutation이 호출되어야 함', () => {});
+});
+```
+
+#### 3.2.5 UX 테스트 (키보드)
+
+```typescript
+describe('WriteDiaryContainer UX', () => {
+  it('키보드가 올라와도 저장 버튼이 보여야 함', () => {});
+  it('전체 폼 영역이 스크롤 가능해야 함', () => {});
+});
+```
+
+---
+
+## 4. 구현 순서
+
+TDD 원칙에 따라 각 기능별로 다음 순서로 진행합니다:
+
+### Phase 1: 기반 작업
+
+1. **테스트 환경 확인**
+   - Jest 설정 확인 및 테스트 실행 가능 여부 확인
+   - 테스트 유틸리티/헬퍼 설정
+
+2. **write-diary feature 내 수정 관련 파일 구조 생성**
+
+### Phase 2: useEditDiaryQueryParams 훅
+
+1. `useEditDiaryQueryParams` 테스트 작성 (Red)
+2. 훅 구현 (Green)
+3. 리팩토링 (Refactor)
+
+### Phase 3: DiaryHashtagInput 컴포넌트
+
+1. 컴포넌트 테스트 작성 (Red)
+2. 컴포넌트 구현 (Green)
+3. 스타일 및 리팩토링 (Refactor)
+
+### Phase 4: EditDiaryContainer
+
+1. 컨테이너 테스트 작성 (Red)
+2. 컨테이너 구현 (Green) - 기존 컴포넌트 재사용
+3. app router 연결 (`src/app/(app)/edit-diary.tsx`)
+
+### Phase 5: 삭제 기능
+
+1. 삭제 모달 테스트 작성 (Red)
+2. 삭제 모달 구현 (Green)
+3. 삭제 mutation 연동 및 쿼리 무효화
+
+### Phase 6: UX 개선 (write-diary)
+
+1. 키보드 처리 테스트 작성 (Red)
+2. `react-native-keyboard-controller` + `ScrollView` 적용 (Green)
+3. 애니메이션 및 UX 개선 (Refactor)
+
+### Phase 7: 드롭다운 메뉴 통합
+
+1. 바텀시트/피드에 Dropdown 컴포넌트 통합
+2. 수정/삭제 액션 연결
+
+---
+
+## 5. 파일 변경 목록 (예상)
+
+### 신규 파일
+
+```
+src/features/write-diary/
+├── __tests__/
+│   ├── useEditDiaryQueryParams.test.ts
+│   ├── DiaryHashtagInput.test.tsx
+│   └── EditDiaryContainer.test.tsx
+├── components/
+│   └── DiaryHashtagInput.tsx
+├── containers/
+│   └── EditDiaryContainer.tsx
+└── hooks/
+    └── useEditDiaryQueryParams.ts
+
+src/app/(app)/
+└── edit-diary.tsx                           # 신규 라우터
+```
+
+### 수정 파일
+
+- `src/features/write-diary/containers/WriteDiaryContainer.tsx` (ScrollView, 키보드 처리)
+- 바텀시트/피드 관련 파일 (드롭다운 추가)
+
+---
+
+## 6. 의존성 및 고려사항
+
+### 기술적 의존성
+
+- `@tanstack/react-query`: 상태 관리 및 캐시 무효화
+- `expo-router`: 네비게이션 및 쿼리 파라미터
+- `react-native-keyboard-controller`: 키보드 처리 (이미 설치됨)
+- `@gorhom/bottom-sheet`: 바텀시트 (이미 설치됨)
+- `src/core/Dropdown`: 드롭다운 메뉴 (이미 구현됨)
+- `src/modules/modal`: 모달 관리 (useModal 훅)
+
+### 라우팅 주의사항
+
+- Tabs 내부에서 `router.navigate` 사용 시 주의 (런타임 에러 가능)
+- 수정/삭제 성공 후에는 `router.dismissAll()` 사용
+
+### 고려사항
+
+1. **낙관적 업데이트**: 삭제 시 UX를 위해 낙관적 업데이트 고려
+2. **에러 처리**: 네트워크 오류, 권한 오류 등 예외 케이스 처리
+3. **로딩 상태**: 수정/삭제 중 중복 요청 방지
+4. **접근성**: 모달, 드롭다운의 접근성 고려
+
+---
+
+## 7. 참고 자료
+
+### TDD Best Practices
+
+- [Test-Driven Development with React and TypeScript](https://link.springer.com/book/10.1007/978-1-4842-9648-6)
+- [Mastering TDD in React](https://trio.dev/mastering-tdd-in-react/)
+- [React Test-driven Development: From User Story to Completion](https://www.toptal.com/react/tdd-react-user-stories-to-development)
+
+### 프로젝트 내 참조
+
+- `src/apis/_generated/serverAPI.ts`: 자동 생성된 API hooks (`useUpdateDiary`, `useDeleteDiary`, `useGetDailySummary`)
+- `src/apis/_generated/serverAPI.schemas.ts`: 타입 정의 (`DiaryUpdateRequest`, `DiaryDeleteResponse`, `DiaryDetailDTO`)
+- `src/core/Dropdown/`: 드롭다운 컴파운드 컴포넌트
+- `src/modules/modal/`: 모달 관리 (useModal 훅)
+- `src/features/write-diary/`: 작성/수정 관련 컴포넌트 및 컨테이너

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@commitlint/cli": "^19.8.0",
     "@commitlint/config-conventional": "^19.8.0",
     "@tanstack/eslint-plugin-query": "^5.64.2",
+    "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.12",
     "@types/react": "~18.3.12",
     "@types/react-test-renderer": "^18.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@tanstack/eslint-plugin-query':
         specifier: ^5.64.2
         version: 5.71.5(eslint@8.57.1)(typescript@5.8.3)
+      '@testing-library/react-native':
+        specifier: ^13.3.3
+        version: 13.3.3(jest@30.2.0(@types/node@22.14.0)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.8.3)))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.3.20)(react@18.3.1))(react-test-renderer@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.14
@@ -2106,6 +2109,18 @@ packages:
     resolution: {integrity: sha512-mQYM/ObpL8YMDz8vCoUuHkbe8Yu7NnVRH8aBaBa/3zlufjp1f1VuWjeO3TcumNHfuVMDwEAGinsgwrB7OKADiQ==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@testing-library/react-native@13.3.3':
+    resolution: {integrity: sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      jest: '>=29.0.0'
+      react: '>=18.2.0'
+      react-native: '>=0.71'
+      react-test-renderer: '>=18.2.0'
+    peerDependenciesMeta:
+      jest:
+        optional: true
 
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
@@ -5356,6 +5371,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -6098,6 +6117,10 @@ packages:
       react: '>= 15.2.1'
       react-native: '>= 0.30.0'
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -6587,6 +6610,10 @@ packages:
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -10060,6 +10087,18 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.71.10
       react: 18.3.1
+
+  '@testing-library/react-native@13.3.3(jest@30.2.0(@types/node@22.14.0)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.8.3)))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.3.20)(react@18.3.1))(react-test-renderer@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      jest-matcher-utils: 30.2.0
+      picocolors: 1.1.1
+      pretty-format: 30.2.0
+      react: 18.3.1
+      react-native: 0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.3.20)(react@18.3.1)
+      react-test-renderer: 18.3.1(react@18.3.1)
+      redent: 3.0.0
+    optionalDependencies:
+      jest: 30.2.0(@types/node@22.14.0)(ts-node@10.9.2(@types/node@22.14.0)(typescript@5.8.3))
 
   '@tootallnate/once@2.0.0': {}
 
@@ -14076,6 +14115,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -14943,6 +14984,11 @@ snapshots:
       react-native: 0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.3.20)(react@18.3.1)
       ts-object-utils: 0.0.5
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -15483,6 +15529,10 @@ snapshots:
   strip-eof@1.0.0: {}
 
   strip-final-newline@2.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@2.0.1: {}
 

--- a/src/app/(app)/edit-diary.tsx
+++ b/src/app/(app)/edit-diary.tsx
@@ -1,0 +1,8 @@
+import EditDiaryContainer from '@/src/features/write-diary/containers/EditDiaryContainer';
+
+/**
+ * @description 일기 수정 페이지 라우터
+ */
+export default function EditDiaryRouter() {
+  return <EditDiaryContainer />;
+}

--- a/src/features/home/components/DeleteDiaryConfirmModal.tsx
+++ b/src/features/home/components/DeleteDiaryConfirmModal.tsx
@@ -1,0 +1,86 @@
+import { COLOR, FONT_FAMILY } from '@/src/constants/theme';
+import { ModalRoot } from '@/src/modules/modal';
+import styled from 'styled-components/native';
+
+type Props = {
+  isOpen: boolean;
+  isPending: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+const DeleteDiaryConfirmModal = ({ isOpen, isPending, onConfirm, onClose }: Props) => {
+  return (
+    <ModalRoot isOpen={isOpen} onClose={onClose}>
+      <ModalWrapper>
+        <Title>일기를 삭제할까요?</Title>
+        <Description>삭제된 일기는 복구할 수 없습니다.</Description>
+        <ButtonWrapper>
+          <CancelButton onPress={onClose} disabled={isPending}>
+            <CancelButtonText>취소</CancelButtonText>
+          </CancelButton>
+          <ConfirmButton onPress={onConfirm} disabled={isPending}>
+            <ConfirmButtonText>{isPending ? '삭제 중...' : '삭제'}</ConfirmButtonText>
+          </ConfirmButton>
+        </ButtonWrapper>
+      </ModalWrapper>
+    </ModalRoot>
+  );
+};
+
+export default DeleteDiaryConfirmModal;
+
+const ModalWrapper = styled.View`
+  width: 280px;
+  padding: 24px 20px;
+  background-color: ${COLOR.white};
+  border-radius: 16px;
+  align-items: center;
+`;
+
+const Title = styled.Text`
+  font-family: ${FONT_FAMILY.pretendard600};
+  font-size: 18px;
+  color: ${COLOR.title};
+  margin-bottom: 8px;
+`;
+
+const Description = styled.Text`
+  font-family: ${FONT_FAMILY.pretendard400};
+  font-size: 14px;
+  color: ${COLOR.sub1};
+  margin-bottom: 20px;
+`;
+
+const ButtonWrapper = styled.View`
+  flex-direction: row;
+  gap: 12px;
+`;
+
+const CancelButton = styled.TouchableOpacity`
+  flex: 1;
+  padding: 12px 0;
+  background-color: ${COLOR.background};
+  border-radius: 8px;
+  align-items: center;
+`;
+
+const CancelButtonText = styled.Text`
+  font-family: ${FONT_FAMILY.pretendard500};
+  font-size: 14px;
+  color: ${COLOR.sub1};
+`;
+
+const ConfirmButton = styled.TouchableOpacity`
+  flex: 1;
+  padding: 12px 0;
+  background-color: ${COLOR.error};
+  border-radius: 8px;
+  align-items: center;
+`;
+
+const ConfirmButtonText = styled.Text`
+  font-family: ${FONT_FAMILY.pretendard500};
+  font-size: 14px;
+  color: ${COLOR.white};
+`;

--- a/src/features/home/components/DiaryOptionsDropdown.tsx
+++ b/src/features/home/components/DiaryOptionsDropdown.tsx
@@ -19,15 +19,16 @@ type Props = {
   year: number;
   month: number;
   day: number;
+  onDismiss?: () => void;
 };
 
-const DiaryOptionsDropdown = ({ diaryId, year, month, day }: Props) => {
+const DiaryOptionsDropdown = ({ diaryId, year, month, day, onDismiss }: Props) => {
   const router = useRouter();
   const queryClient = useQueryClient();
   const deleteModal = useModal();
   const deleteDiaryMutation = useDeleteDiary();
 
-  const handleDeleteConfirmClick = () => {
+  const handleDeleteConfirmClick = (exit: () => void) => {
     if (deleteDiaryMutation.isPending) return;
     deleteDiaryMutation.mutate(
       { diaryId },
@@ -38,7 +39,8 @@ const DiaryOptionsDropdown = ({ diaryId, year, month, day }: Props) => {
           queryClient.invalidateQueries({ queryKey: getGetDailySummaryQueryKey({ year, month, day }) });
           queryClient.invalidateQueries({ queryKey: getGetFeedQueryKey() });
           queryClient.invalidateQueries({ queryKey: getGetCurrentStreakQueryKey() });
-          router.dismissAll();
+          exit();
+          onDismiss?.();
         },
         onError: () => {
           toast({ message: '삭제에 실패했습니다. 잠시 후 다시 시도해주세요.', options: { type: 'error' } });
@@ -48,6 +50,7 @@ const DiaryOptionsDropdown = ({ diaryId, year, month, day }: Props) => {
   };
 
   const handleEditClick = () => {
+    onDismiss?.();
     router.navigate(`/edit-diary?diaryId=${diaryId}&year=${year}&month=${month}&day=${day}`);
   };
 
@@ -56,7 +59,7 @@ const DiaryOptionsDropdown = ({ diaryId, year, month, day }: Props) => {
       <DeleteDiaryConfirmModal
         isOpen={isOpen}
         isPending={deleteDiaryMutation.isPending}
-        onConfirm={handleDeleteConfirmClick}
+        onConfirm={() => handleDeleteConfirmClick(exit)}
         onClose={exit}
       />
     ));

--- a/src/features/home/components/DiaryOptionsDropdown.tsx
+++ b/src/features/home/components/DiaryOptionsDropdown.tsx
@@ -1,0 +1,84 @@
+import {
+  getGetCalendarViewQueryKey,
+  getGetCurrentStreakQueryKey,
+  getGetDailySummaryQueryKey,
+  getGetFeedQueryKey,
+  useDeleteDiary,
+} from '@/src/apis/_generated/serverAPI';
+import { Dropdown } from '@/src/core/Dropdown';
+import { Body2 } from '@/src/core/Txt';
+import DeleteDiaryConfirmModal from '@/src/features/home/components/DeleteDiaryConfirmModal';
+import { useModal } from '@/src/modules/modal';
+import { toast } from '@/src/modules/toast';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'expo-router';
+import styled from 'styled-components/native';
+
+type Props = {
+  diaryId: number;
+  year: number;
+  month: number;
+  day: number;
+};
+
+const DiaryOptionsDropdown = ({ diaryId, year, month, day }: Props) => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const deleteModal = useModal();
+  const deleteDiaryMutation = useDeleteDiary();
+
+  const handleDeleteConfirmClick = () => {
+    if (deleteDiaryMutation.isPending) return;
+    deleteDiaryMutation.mutate(
+      { diaryId },
+      {
+        onSuccess: () => {
+          toast({ message: '삭제되었습니다.', options: { type: 'success' } });
+          queryClient.invalidateQueries({ queryKey: getGetCalendarViewQueryKey({ year, month }) });
+          queryClient.invalidateQueries({ queryKey: getGetDailySummaryQueryKey({ year, month, day }) });
+          queryClient.invalidateQueries({ queryKey: getGetFeedQueryKey() });
+          queryClient.invalidateQueries({ queryKey: getGetCurrentStreakQueryKey() });
+          router.dismissAll();
+        },
+        onError: () => {
+          toast({ message: '삭제에 실패했습니다. 잠시 후 다시 시도해주세요.', options: { type: 'error' } });
+        },
+      }
+    );
+  };
+
+  const handleEditClick = () => {
+    router.navigate(`/edit-diary?diaryId=${diaryId}&year=${year}&month=${month}&day=${day}`);
+  };
+
+  const handleDeleteClick = () => {
+    deleteModal.open(({ isOpen, exit }) => (
+      <DeleteDiaryConfirmModal
+        isOpen={isOpen}
+        isPending={deleteDiaryMutation.isPending}
+        onConfirm={handleDeleteConfirmClick}
+        onClose={exit}
+      />
+    ));
+  };
+
+  return (
+    <Dropdown>
+      <Dropdown.Trigger />
+      <Dropdown.Menu align="end">
+        <Dropdown.Item onPress={handleEditClick}>
+          <DropdownItemText>수정</DropdownItemText>
+        </Dropdown.Item>
+        <Dropdown.Item onPress={handleDeleteClick}>
+          <DropdownItemText>삭제</DropdownItemText>
+        </Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+};
+
+export default DiaryOptionsDropdown;
+
+const DropdownItemText = styled(Body2)`
+  color: ${({ theme }) => theme.title};
+`;

--- a/src/features/home/components/bottomSheet/DiaryBottomSheet.tsx
+++ b/src/features/home/components/bottomSheet/DiaryBottomSheet.tsx
@@ -60,7 +60,12 @@ const DiaryBottomSheet = forwardRef<BottomSheet, Props>(({ date }, ref) => {
       >
         {dayData && (
           <Wrapper onLayout={getBottomSheetWidth}>
-            <DiaryBottomSheetList key={`${date.year}-${date.month}-${date.day}`} width={width} dayData={dayData} />
+            <DiaryBottomSheetList
+              key={`${date.year}-${date.month}-${date.day}`}
+              width={width}
+              dayData={dayData}
+              onClose={() => bottomSheetRef.current?.close()}
+            />
           </Wrapper>
         )}
       </StyledBottomSheet>

--- a/src/features/home/components/bottomSheet/DiaryBottomSheetList.tsx
+++ b/src/features/home/components/bottomSheet/DiaryBottomSheetList.tsx
@@ -6,9 +6,10 @@ import DiaryBottomSheetListItem from './DiaryBottomSheetListItem';
 type Props = {
   width: number | null;
   dayData: NonNullable<DailySummaryResponseDTO>;
+  onClose: () => void;
 };
 
-const DiaryBottomSheetList = ({ width, dayData }: Props) => {
+const DiaryBottomSheetList = ({ width, dayData, onClose }: Props) => {
   const { year, month, day } = dayData;
 
   const diaries = dayData.diaries.filter(isRequiredDiaryDetail);
@@ -19,7 +20,9 @@ const DiaryBottomSheetList = ({ width, dayData }: Props) => {
       width={width}
       data={diaries}
       loop={false}
-      renderItem={({ item }) => <DiaryBottomSheetListItem date={{ year, month, day }} diaryData={item} />}
+      renderItem={({ item }) => (
+        <DiaryBottomSheetListItem date={{ year, month, day }} diaryData={item} onClose={onClose} />
+      )}
       onConfigurePanGesture={(gestureChain) => gestureChain.activeOffsetX([-10, 10])}
     />
   );

--- a/src/features/home/components/bottomSheet/DiaryBottomSheetListItem.tsx
+++ b/src/features/home/components/bottomSheet/DiaryBottomSheetListItem.tsx
@@ -13,9 +13,10 @@ import ShareModal from '../shareModal/ShareModal';
 type Props = {
   date: TDate;
   diaryData: Required<DiaryDetailDTO>;
+  onClose: () => void;
 };
 
-const DiaryBottomSheetListItem = ({ date, diaryData }: Props) => {
+const DiaryBottomSheetListItem = ({ date, diaryData, onClose }: Props) => {
   const shareModal = useModal();
 
   const handleShareModalOpen = () => {
@@ -34,7 +35,13 @@ const DiaryBottomSheetListItem = ({ date, diaryData }: Props) => {
           <ShareButton hitSlop={5} onPress={handleShareModalOpen}>
             <IconShared />
           </ShareButton>
-          <DiaryOptionsDropdown diaryId={diaryData.diaryId} year={date.year} month={date.month} day={date.day} />
+          <DiaryOptionsDropdown
+            diaryId={diaryData.diaryId}
+            year={date.year}
+            month={date.month}
+            day={date.day}
+            onDismiss={onClose}
+          />
         </ActionButtonWrapper>
         <StyledDateTxt color="title">
           {date.year}년 {date.month}월 {date.day}일

--- a/src/features/home/components/bottomSheet/DiaryBottomSheetListItem.tsx
+++ b/src/features/home/components/bottomSheet/DiaryBottomSheetListItem.tsx
@@ -7,6 +7,7 @@ import { Image } from 'expo-image';
 import styled from 'styled-components/native';
 import type { TDate } from '../../types';
 import DiaryCreatedByInfo from '../DiaryCreatedByInfo';
+import DiaryOptionsDropdown from '../DiaryOptionsDropdown';
 import ShareModal from '../shareModal/ShareModal';
 
 type Props = {
@@ -29,9 +30,12 @@ const DiaryBottomSheetListItem = ({ date, diaryData }: Props) => {
         {diaryData.imageUrl ? <StyledImage source={{ uri: diaryData.imageUrl }} /> : <PlaceholderImage />}
       </ImageWrapper>
       <RelativeWrapper>
-        <ShareButton hitSlop={5} onPress={handleShareModalOpen}>
-          <IconShared />
-        </ShareButton>
+        <ActionButtonWrapper>
+          <ShareButton hitSlop={5} onPress={handleShareModalOpen}>
+            <IconShared />
+          </ShareButton>
+          <DiaryOptionsDropdown diaryId={diaryData.diaryId} year={date.year} month={date.month} day={date.day} />
+        </ActionButtonWrapper>
         <StyledDateTxt color="title">
           {date.year}년 {date.month}월 {date.day}일
         </StyledDateTxt>
@@ -71,12 +75,17 @@ const RelativeWrapper = styled.View`
   position: relative;
 `;
 
-const ShareButton = styled.TouchableOpacity`
+const ActionButtonWrapper = styled.View`
   position: absolute;
   top: 0;
   right: 0;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
   z-index: 10;
 `;
+
+const ShareButton = styled.TouchableOpacity``;
 
 const StyledDateTxt = styled(Description2)`
   line-height: 18px;

--- a/src/features/home/components/feed/FeedDiaryListItem.tsx
+++ b/src/features/home/components/feed/FeedDiaryListItem.tsx
@@ -9,6 +9,7 @@ import type { LayoutChangeEvent } from 'react-native';
 import styled from 'styled-components/native';
 import type { TDate } from '../../types';
 import DiaryCreatedByInfo from '../DiaryCreatedByInfo';
+import DiaryOptionsDropdown from '../DiaryOptionsDropdown';
 import ShareModal from '../shareModal/ShareModal';
 
 type Props = {
@@ -32,9 +33,12 @@ const FeedDiaryListItem = ({ date, diaryData, onLayout }: Props) => {
         {diaryData.imageUrl ? <StyledImage source={{ uri: diaryData.imageUrl }} /> : <PlaceholderImage />}
       </ImageWrapper>
       <RelativeWrapper>
-        <ShareButton hitSlop={5} onPress={handleShareModalOpen}>
-          <IconShared />
-        </ShareButton>
+        <ActionButtonWrapper>
+          <ShareButton hitSlop={5} onPress={handleShareModalOpen}>
+            <IconShared />
+          </ShareButton>
+          <DiaryOptionsDropdown diaryId={diaryData.diaryId} year={date.year} month={date.month} day={date.day} />
+        </ActionButtonWrapper>
         <StyledDateTxt color="title">
           {date.year}년 {date.month}월 {date.day}일
         </StyledDateTxt>
@@ -77,12 +81,17 @@ const RelativeWrapper = styled.View`
   position: relative;
 `;
 
-const ShareButton = styled.TouchableOpacity`
+const ActionButtonWrapper = styled.View`
   position: absolute;
   top: 0;
   right: 0;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
   z-index: 10;
 `;
+
+const ShareButton = styled.TouchableOpacity``;
 
 const StyledDateTxt = styled(Description2)`
   line-height: 18px;

--- a/src/features/home/utils/typeGuard.ts
+++ b/src/features/home/utils/typeGuard.ts
@@ -12,5 +12,5 @@ export const isCalendarDayData = (value: DailySummaryResponseDTO): value is Cale
 };
 
 export const isRequiredDiaryDetail = (value: DiaryDetailDTO): value is Required<DiaryDetailDTO> => {
-  return !!value.title && !!value.content && !!value.hashtag1 && !!value.hashtag2 && !!value.mood;
+  return !!value.title && !!value.content && !!value.hashtag1 && !!value.hashtag2;
 };

--- a/src/features/write-diary/__tests__/DiaryHashtagInput.test.tsx
+++ b/src/features/write-diary/__tests__/DiaryHashtagInput.test.tsx
@@ -11,21 +11,21 @@ describe('DiaryHashtagInput', () => {
   });
 
   it('value 렌더링 확인', () => {
-    const value = '#태그';
+    const value = '태그';
     render(<DiaryHashtagInput value={value} onValueChange={jest.fn()} />);
 
     expect(screen.getByDisplayValue(value)).toBeTruthy();
   });
 
   it('placeholder 렌더링 확인', () => {
-    const placeholder = '#태그';
+    const placeholder = '태그1';
     render(<DiaryHashtagInput value="" onValueChange={jest.fn()} placeholder={placeholder} />);
 
     expect(screen.getByPlaceholderText(placeholder)).toBeTruthy();
   });
 
   it('5자 이하 입력 시 onValueChange 호출 확인', () => {
-    const changedValue = '#테스트';
+    const changedValue = '테스트';
     const onValueChange = jest.fn();
     render(<DiaryHashtagInput value="" onValueChange={onValueChange} />);
     fireEvent.changeText(screen.getByTestId(TEST_ID), changedValue);
@@ -33,10 +33,10 @@ describe('DiaryHashtagInput', () => {
     expect(onValueChange).toHaveBeenCalledWith(changedValue);
   });
 
-  it('# 포함 5자 초과 시 onValueChange가 호출되지 않아야 함', () => {
+  it('5자 초과 시 onValueChange가 호출되지 않아야 함', () => {
     const onValueChange = jest.fn();
     render(<DiaryHashtagInput value="" onValueChange={onValueChange} />);
-    fireEvent.changeText(screen.getByTestId(TEST_ID), '#여섯글자야');
+    fireEvent.changeText(screen.getByTestId(TEST_ID), '여섯여섯여섯');
 
     expect(onValueChange).not.toHaveBeenCalled();
   });

--- a/src/features/write-diary/__tests__/DiaryHashtagInput.test.tsx
+++ b/src/features/write-diary/__tests__/DiaryHashtagInput.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import DiaryHashtagInput from '../components/DiaryHashtagInput';
+
+const TEST_ID = 'diary-hashtag-input';
+
+describe('DiaryHashtagInput', () => {
+  it('해시태그 입력 필드 렌더링 확인', () => {
+    render(<DiaryHashtagInput value="" onValueChange={jest.fn()} />);
+
+    expect(screen.getByTestId(TEST_ID)).toBeTruthy();
+  });
+
+  it('value 렌더링 확인', () => {
+    const value = '#태그';
+    render(<DiaryHashtagInput value={value} onValueChange={jest.fn()} />);
+
+    expect(screen.getByDisplayValue(value)).toBeTruthy();
+  });
+
+  it('placeholder 렌더링 확인', () => {
+    const placeholder = '#태그';
+    render(<DiaryHashtagInput value="" onValueChange={jest.fn()} placeholder={placeholder} />);
+
+    expect(screen.getByPlaceholderText(placeholder)).toBeTruthy();
+  });
+
+  it('5자 이하 입력 시 onValueChange 호출 확인', () => {
+    const changedValue = '#테스트';
+    const onValueChange = jest.fn();
+    render(<DiaryHashtagInput value="" onValueChange={onValueChange} />);
+    fireEvent.changeText(screen.getByTestId(TEST_ID), changedValue);
+
+    expect(onValueChange).toHaveBeenCalledWith(changedValue);
+  });
+
+  it('# 포함 5자 초과 시 onValueChange가 호출되지 않아야 함', () => {
+    const onValueChange = jest.fn();
+    render(<DiaryHashtagInput value="" onValueChange={onValueChange} />);
+    fireEvent.changeText(screen.getByTestId(TEST_ID), '#여섯글자야');
+
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/write-diary/__tests__/useEditDiaryQueryParams.test.ts
+++ b/src/features/write-diary/__tests__/useEditDiaryQueryParams.test.ts
@@ -1,0 +1,97 @@
+import { renderHook } from '@testing-library/react-native';
+import { useEditDiaryQueryParams } from '../hooks/useEditDiaryQueryParams';
+
+const mockParams: Record<string, string | undefined> = {};
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => mockParams,
+}));
+
+describe('useEditDiaryQueryParams', () => {
+  beforeEach(() => {
+    Object.keys(mockParams).forEach((key) => delete mockParams[key]);
+    console.error = jest.fn();
+  });
+
+  it('diaryId, year, month, day를 숫자로 변환해 반환', () => {
+    mockParams.diaryId = '123';
+    mockParams.year = '2024';
+    mockParams.month = '3';
+    mockParams.day = '15';
+
+    const { result } = renderHook(() => useEditDiaryQueryParams());
+    expect(result.current).toEqual({ diaryId: 123, year: 2024, month: 3, day: 15 });
+  });
+
+  describe('필수 파라미터 누락', () => {
+    it('diaryId가 없으면 에러 throw', () => {
+      mockParams.year = '2024';
+      mockParams.month = '3';
+      mockParams.day = '15';
+
+      expect(() => renderHook(() => useEditDiaryQueryParams())).toThrow();
+    });
+
+    it('year가 없으면 에러 throw', () => {
+      mockParams.diaryId = '123';
+      mockParams.month = '3';
+      mockParams.day = '15';
+
+      expect(() => renderHook(() => useEditDiaryQueryParams())).toThrow();
+    });
+
+    it('month가 없으면 에러 throw', () => {
+      mockParams.diaryId = '123';
+      mockParams.year = '2024';
+      mockParams.day = '15';
+
+      expect(() => renderHook(() => useEditDiaryQueryParams())).toThrow();
+    });
+
+    it('day가 없으면 에러 throw', () => {
+      mockParams.diaryId = '123';
+      mockParams.year = '2024';
+      mockParams.month = '3';
+
+      expect(() => renderHook(() => useEditDiaryQueryParams())).toThrow();
+    });
+  });
+
+  describe('파라미터가 숫자가 아닌 경우', () => {
+    it('diaryId가 숫자가 아니면 에러 throw', () => {
+      mockParams.diaryId = 'abc';
+      mockParams.year = '2024';
+      mockParams.month = '3';
+      mockParams.day = '15';
+
+      expect(() => renderHook(() => useEditDiaryQueryParams())).toThrow();
+    });
+
+    it('year가 숫자가 아니면 에러 throw', () => {
+      mockParams.diaryId = '123';
+      mockParams.year = 'abc';
+      mockParams.month = '3';
+      mockParams.day = '15';
+
+      expect(() => renderHook(() => useEditDiaryQueryParams())).toThrow();
+    });
+
+    it('month가 숫자가 아니면 에러 throw', () => {
+      mockParams.diaryId = '123';
+      mockParams.year = '2024';
+      mockParams.month = 'abc';
+      mockParams.day = '15';
+
+      expect(() => renderHook(() => useEditDiaryQueryParams())).toThrow();
+    });
+
+    it('day가 숫자가 아니면 에러 throw', () => {
+      mockParams.diaryId = '123';
+      mockParams.year = '2024';
+      mockParams.month = '3';
+      mockParams.day = 'abc';
+
+      expect(() => renderHook(() => useEditDiaryQueryParams())).toThrow();
+    });
+  });
+});

--- a/src/features/write-diary/components/DiaryHashtagInput.tsx
+++ b/src/features/write-diary/components/DiaryHashtagInput.tsx
@@ -1,0 +1,39 @@
+import { COLOR, FONT_FAMILY } from '@/src/constants/theme';
+import styled from 'styled-components/native';
+
+type Props = {
+  value: string;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+};
+
+const MAX_LENGTH = 5;
+
+const DiaryHashtagInput = ({ value, onValueChange, placeholder }: Props) => {
+  const handleChangeText = (text: string) => {
+    if (text.length > MAX_LENGTH) return;
+    onValueChange(text);
+  };
+
+  return (
+    <StyledTextInput
+      testID="diary-hashtag-input"
+      value={value}
+      onChangeText={handleChangeText}
+      placeholder={placeholder}
+      placeholderTextColor={COLOR.placeholder}
+      maxLength={MAX_LENGTH}
+    />
+  );
+};
+
+export default DiaryHashtagInput;
+
+const StyledTextInput = styled.TextInput`
+  padding: 12px 16px;
+  background-color: ${COLOR.white};
+  border-radius: 12px;
+  font-family: ${FONT_FAMILY.pretendard500};
+  font-size: 14px;
+  color: ${COLOR.title};
+`;

--- a/src/features/write-diary/containers/EditDiaryContainer.tsx
+++ b/src/features/write-diary/containers/EditDiaryContainer.tsx
@@ -23,16 +23,43 @@ import { useEditDiaryQueryParams } from '../hooks/useEditDiaryQueryParams';
 const EditDiaryContainer = () => {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { diaryId, year, month, day } = useEditDiaryQueryParams();
-
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');
   const [hashtag1, setHashtag1] = useState<string>('');
   const [hashtag2, setHashtag2] = useState<string>('');
+  const { diaryId, year, month, day } = useEditDiaryQueryParams();
 
   const { data, isLoading } = useGetDailySummary({ year, month, day });
+  const updateDiaryMutation = useUpdateDiary();
 
+  const isFormValid = title.trim() && content.trim() && hashtag1.trim() && hashtag2.trim();
   const diary = data?.result?.diaries?.find((d) => d.diaryId === diaryId);
+
+  const handleBackClick = () => {
+    router.back();
+  };
+
+  const handleSubmitClick = () => {
+    if (!isFormValid || updateDiaryMutation.isPending) return;
+    updateDiaryMutation.mutate(
+      {
+        diaryId,
+        data: { title, content, hashtag1, hashtag2 },
+      },
+      {
+        onSuccess: () => {
+          toast({ message: '수정되었습니다.', options: { type: 'success' } });
+          queryClient.invalidateQueries({ queryKey: getGetCalendarViewQueryKey({ year, month }) });
+          queryClient.invalidateQueries({ queryKey: getGetFeedQueryKey() });
+          queryClient.invalidateQueries({ queryKey: getGetCurrentStreakQueryKey() });
+          router.dismissAll();
+        },
+        onError: () => {
+          toast({ message: '수정에 실패했습니다. 잠시 후 다시 시도해주세요.', options: { type: 'error' } });
+        },
+      }
+    );
+  };
 
   useEffect(() => {
     if (diary) {
@@ -42,40 +69,6 @@ const EditDiaryContainer = () => {
       setHashtag2(diary.hashtag2 ?? '');
     }
   }, [diary]);
-
-  const isFormValid = title.trim() && content.trim() && hashtag1.trim() && hashtag2.trim();
-
-  const updateDiaryMutation = useUpdateDiary({
-    mutation: {
-      onError: () => {
-        toast({ message: '수정에 실패했습니다. 잠시 후 다시 시도해주세요.', options: { type: 'error' } });
-      },
-      onSuccess: () => {
-        toast({ message: '수정되었습니다.', options: { type: 'success' } });
-        queryClient.invalidateQueries({ queryKey: getGetCalendarViewQueryKey({ year, month }) });
-        queryClient.invalidateQueries({ queryKey: getGetFeedQueryKey() });
-        queryClient.invalidateQueries({ queryKey: getGetCurrentStreakQueryKey() });
-        router.dismissAll();
-      },
-    },
-  });
-
-  const handleBackClick = () => {
-    router.back();
-  };
-
-  const handleSubmit = () => {
-    if (!isFormValid || updateDiaryMutation.isPending) return;
-    updateDiaryMutation.mutate({
-      diaryId,
-      data: {
-        title,
-        content,
-        hashtag1: hashtag1 || null,
-        hashtag2: hashtag2 || null,
-      },
-    });
-  };
 
   if (isLoading) {
     return (
@@ -88,9 +81,9 @@ const EditDiaryContainer = () => {
   }
 
   return (
-    <SafeView>
-      <WriteDiaryHeader onBackClick={handleBackClick}>{`${year}년 ${month}월 ${day}일`}</WriteDiaryHeader>
-      <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <SafeView>
+        <WriteDiaryHeader onBackClick={handleBackClick}>{`${year}년 ${month}월 ${day}일`}</WriteDiaryHeader>
         <ContentWrapper>
           <DiaryTitleInput value={title} onValueChange={setTitle} />
           <DiaryContentInput value={content} onValueChange={setContent} />
@@ -99,13 +92,13 @@ const EditDiaryContainer = () => {
             <DiaryHashtagInput value={hashtag2} onValueChange={setHashtag2} placeholder="#태그2" />
           </HashtagWrapper>
         </ContentWrapper>
-      </TouchableWithoutFeedback>
-      <ButtonWrapper>
-        <PrimaryButton size="large" disabled={!isFormValid} onPress={handleSubmit}>
-          수정 완료
-        </PrimaryButton>
-      </ButtonWrapper>
-    </SafeView>
+        <ButtonWrapper>
+          <PrimaryButton size="large" disabled={!isFormValid} onPress={handleSubmitClick}>
+            수정 완료
+          </PrimaryButton>
+        </ButtonWrapper>
+      </SafeView>
+    </TouchableWithoutFeedback>
   );
 };
 

--- a/src/features/write-diary/containers/EditDiaryContainer.tsx
+++ b/src/features/write-diary/containers/EditDiaryContainer.tsx
@@ -1,0 +1,139 @@
+import {
+  getGetCalendarViewQueryKey,
+  getGetCurrentStreakQueryKey,
+  getGetFeedQueryKey,
+  useGetDailySummary,
+  useUpdateDiary,
+} from '@/src/apis/_generated/serverAPI';
+import { COLOR } from '@/src/constants/theme';
+import { PrimaryButton } from '@/src/core/Button';
+import { toast } from '@/src/modules/toast';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { ActivityIndicator, Keyboard, TouchableWithoutFeedback, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import styled from 'styled-components/native';
+import DiaryContentInput from '../components/DiaryContentInput';
+import DiaryHashtagInput from '../components/DiaryHashtagInput';
+import DiaryTitleInput from '../components/DiaryTitleInput';
+import WriteDiaryHeader from '../components/WriteDiaryHeader';
+import { useEditDiaryQueryParams } from '../hooks/useEditDiaryQueryParams';
+
+const EditDiaryContainer = () => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { diaryId, year, month, day } = useEditDiaryQueryParams();
+
+  const [title, setTitle] = useState<string>('');
+  const [content, setContent] = useState<string>('');
+  const [hashtag1, setHashtag1] = useState<string>('');
+  const [hashtag2, setHashtag2] = useState<string>('');
+
+  const { data, isLoading } = useGetDailySummary({ year, month, day });
+
+  const diary = data?.result?.diaries?.find((d) => d.diaryId === diaryId);
+
+  useEffect(() => {
+    if (diary) {
+      setTitle(diary.title ?? '');
+      setContent(diary.content ?? '');
+      setHashtag1(diary.hashtag1 ?? '');
+      setHashtag2(diary.hashtag2 ?? '');
+    }
+  }, [diary]);
+
+  const isFormValid = title.trim() && content.trim() && hashtag1.trim() && hashtag2.trim();
+
+  const updateDiaryMutation = useUpdateDiary({
+    mutation: {
+      onError: () => {
+        toast({ message: '수정에 실패했습니다. 잠시 후 다시 시도해주세요.', options: { type: 'error' } });
+      },
+      onSuccess: () => {
+        toast({ message: '수정되었습니다.', options: { type: 'success' } });
+        queryClient.invalidateQueries({ queryKey: getGetCalendarViewQueryKey({ year, month }) });
+        queryClient.invalidateQueries({ queryKey: getGetFeedQueryKey() });
+        queryClient.invalidateQueries({ queryKey: getGetCurrentStreakQueryKey() });
+        router.dismissAll();
+      },
+    },
+  });
+
+  const handleBackClick = () => {
+    router.back();
+  };
+
+  const handleSubmit = () => {
+    if (!isFormValid || updateDiaryMutation.isPending) return;
+    updateDiaryMutation.mutate({
+      diaryId,
+      data: {
+        title,
+        content,
+        hashtag1: hashtag1 || null,
+        hashtag2: hashtag2 || null,
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <SafeView>
+        <LoadingWrapper>
+          <ActivityIndicator size="large" color={COLOR.main} />
+        </LoadingWrapper>
+      </SafeView>
+    );
+  }
+
+  return (
+    <SafeView>
+      <WriteDiaryHeader onBackClick={handleBackClick}>{`${year}년 ${month}월 ${day}일`}</WriteDiaryHeader>
+      <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
+        <ContentWrapper>
+          <DiaryTitleInput value={title} onValueChange={setTitle} />
+          <DiaryContentInput value={content} onValueChange={setContent} />
+          <HashtagWrapper>
+            <DiaryHashtagInput value={hashtag1} onValueChange={setHashtag1} placeholder="#태그1" />
+            <DiaryHashtagInput value={hashtag2} onValueChange={setHashtag2} placeholder="#태그2" />
+          </HashtagWrapper>
+        </ContentWrapper>
+      </TouchableWithoutFeedback>
+      <ButtonWrapper>
+        <PrimaryButton size="large" disabled={!isFormValid} onPress={handleSubmit}>
+          수정 완료
+        </PrimaryButton>
+      </ButtonWrapper>
+    </SafeView>
+  );
+};
+
+export default EditDiaryContainer;
+
+const SafeView = styled(SafeAreaView)`
+  flex: 1;
+  background-color: ${COLOR.background};
+  padding: 0 18px;
+`;
+
+const LoadingWrapper = styled(View)`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ContentWrapper = styled.View`
+  flex: 1;
+  gap: 12px;
+`;
+
+const HashtagWrapper = styled.View`
+  flex-direction: row;
+  gap: 8px;
+`;
+
+const ButtonWrapper = styled.View`
+  margin: 0 auto;
+  padding-bottom: 20px;
+`;

--- a/src/features/write-diary/containers/EditDiaryContainer.tsx
+++ b/src/features/write-diary/containers/EditDiaryContainer.tsx
@@ -88,8 +88,8 @@ const EditDiaryContainer = () => {
           <DiaryTitleInput value={title} onValueChange={setTitle} />
           <DiaryContentInput value={content} onValueChange={setContent} />
           <HashtagWrapper>
-            <DiaryHashtagInput value={hashtag1} onValueChange={setHashtag1} placeholder="#태그1" />
-            <DiaryHashtagInput value={hashtag2} onValueChange={setHashtag2} placeholder="#태그2" />
+            <DiaryHashtagInput value={hashtag1} onValueChange={setHashtag1} placeholder="태그1" />
+            <DiaryHashtagInput value={hashtag2} onValueChange={setHashtag2} placeholder="태그2" />
           </HashtagWrapper>
         </ContentWrapper>
         <ButtonWrapper>

--- a/src/features/write-diary/containers/WriteDiaryContainer.tsx
+++ b/src/features/write-diary/containers/WriteDiaryContainer.tsx
@@ -25,47 +25,54 @@ const WriteDiaryContainer = () => {
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');
 
-  const isFormValid = title.trim() && content.trim();
+  const createManualDiaryMutation = useCreateManualDiary();
 
-  const createManualDiaryMutation = useCreateManualDiary({
-    mutation: {
-      onError: () => {
-        toast({ message: '저장에 실패했습니다. 잠시 후 다시 시도해주세요.', options: { type: 'error' } });
-      },
-      onSuccess: () => {
-        toast({ message: '저장되었습니다.', options: { type: 'success' } });
-        queryClient.invalidateQueries({ queryKey: getGetCalendarViewQueryKey({ year, month }) });
-        queryClient.invalidateQueries({ queryKey: getGetFeedQueryKey() });
-        queryClient.invalidateQueries({ queryKey: getGetCurrentStreakQueryKey() });
-        router.dismissAll();
-      },
-    },
-  });
+  const isFormValid = title.trim() && content.trim();
 
   const handleBackClick = () => {
     router.back();
   };
 
-  const handleSubmit = () => {
+  const handleSubmitClick = () => {
     if (!isFormValid || createManualDiaryMutation.isPending) return;
-    createManualDiaryMutation.mutate({ data: { aiProfileId: 1, year, month, day, title, content } });
+    createManualDiaryMutation.mutate(
+      {
+        data: { aiProfileId: 1, year, month, day, title, content },
+      },
+      {
+        onSuccess: () => {
+          toast({ message: '저장되었습니다.', options: { type: 'success' } });
+          queryClient.invalidateQueries({ queryKey: getGetCalendarViewQueryKey({ year, month }) });
+          queryClient.invalidateQueries({ queryKey: getGetFeedQueryKey() });
+          queryClient.invalidateQueries({ queryKey: getGetCurrentStreakQueryKey() });
+          router.dismissAll();
+        },
+        onError: () => {
+          toast({ message: '저장에 실패했습니다. 잠시 후 다시 시도해주세요.', options: { type: 'error' } });
+        },
+      }
+    );
   };
 
   return (
-    <SafeView>
-      <WriteDiaryHeader onBackClick={handleBackClick}>{`${year}년 ${month}월 ${day}일`}</WriteDiaryHeader>
-      <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
+    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+      <SafeView>
+        <WriteDiaryHeader onBackClick={handleBackClick}>{`${year}년 ${month}월 ${day}일`}</WriteDiaryHeader>
         <ContentWrapper>
           <DiaryTitleInput value={title} onValueChange={setTitle} />
           <DiaryContentInput value={content} onValueChange={setContent} />
         </ContentWrapper>
-      </TouchableWithoutFeedback>
-      <ButtonWrapper>
-        <PrimaryButton size="large" disabled={!isFormValid} onPress={handleSubmit}>
-          일기 저장하기
-        </PrimaryButton>
-      </ButtonWrapper>
-    </SafeView>
+        <ButtonWrapper>
+          <PrimaryButton
+            size="large"
+            disabled={!isFormValid || createManualDiaryMutation.isPending}
+            onPress={handleSubmitClick}
+          >
+            {createManualDiaryMutation.isPending ? '일기 저장중...' : '일기 저장하기'}
+          </PrimaryButton>
+        </ButtonWrapper>
+      </SafeView>
+    </TouchableWithoutFeedback>
   );
 };
 

--- a/src/features/write-diary/hooks/useEditDiaryQueryParams.ts
+++ b/src/features/write-diary/hooks/useEditDiaryQueryParams.ts
@@ -1,0 +1,27 @@
+import { useLocalSearchParams } from 'expo-router';
+
+type Params = {
+  diaryId?: string;
+  year?: string;
+  month?: string;
+  day?: string;
+};
+
+export const useEditDiaryQueryParams = () => {
+  const params = useLocalSearchParams<Params>();
+
+  if (!params || !params.diaryId || !params.year || !params.month || !params.day) {
+    throw new Error('쿼리 파라미터 diaryId, year, month, day를 전달했는지 확인해주세요.');
+  }
+
+  const diaryId = Number(params.diaryId);
+  const year = Number(params.year);
+  const month = Number(params.month);
+  const day = Number(params.day);
+
+  if (isNaN(diaryId) || isNaN(year) || isNaN(month) || isNaN(day)) {
+    throw new Error('쿼리 파라미터 diaryId, year, month, day가 숫자인지 확인해주세요.');
+  }
+
+  return { diaryId, year, month, day };
+};


### PR DESCRIPTION
## 👀 관련 이슈

> [!WARNING]
> 현재 IOS RN 빌드가 불가능한 이슈가 존재합니다. https://github.com/expo/expo/issues/44229#issuecomment-4125779703
> Expo 버전 업, 해당 이슈 Resolved 대기 후 상용 배포가 필요합니다.

close #227 

## ✨ 작업한 내용

- [x] 테스트 환경 확인 및 기반 작업
- [x] useEditDiaryQueryParams 훅 추가 (TDD)
- [x] DiaryHashtagInput 컴포넌트 추가 (TDD)
- [x] EditDiaryContainer 구현, app router 연결
- [x] 삭제 기능 연결 (드롭다운 -> 모달 -> mutation)
- [x] 드롭다운 컴포넌트 구현, 수정/삭제 연결
- [x] UX 개선 (일기 수동 작성, 일기 수정 페이지에서 바깥 누르면 키보드 닫히도록)

## 📷스크린샷 / 영상

| 드롭다운 | 일기 수정 페이지 | 일기 삭제 모달 |
|--------|--------------|-------------|
| <img width="432" height="896" alt="스크린샷 2026-03-26 01 08 16" src="https://github.com/user-attachments/assets/5bc29315-ec30-4066-b611-42dc721f0720" /> | <img width="432" height="896" alt="스크린샷 2026-03-26 01 08 29" src="https://github.com/user-attachments/assets/09286768-143c-420a-b9f4-e44016e79655" /> | <img width="432" height="893" alt="스크린샷 2026-03-26 01 08 43" src="https://github.com/user-attachments/assets/6a540b73-97ab-40ec-b9c4-55daefbefc70" /> |
