### PR TITLE
[main] Android 튜토리얼 OOM 크래시 대응

### DIFF
--- a/src/features/tutorial/components/TutorialListItem.tsx
+++ b/src/features/tutorial/components/TutorialListItem.tsx
@@ -1,10 +1,9 @@
 import { COLOR } from '@/src/constants/theme';
 import { Body2, MiddleTitle } from '@/src/core/Txt';
-import { VideoView, useVideoPlayer } from 'expo-video';
-import { useEffect } from 'react';
 import type { CarouselRenderItemInfo } from 'react-native-reanimated-carousel/lib/typescript/types';
 import styled from 'styled-components/native';
 import type { TUTORIAL_LIST_DATA } from '../constants';
+import TutorialVideoPlayer from './TutorialVideoPlayer';
 
 type Props = CarouselRenderItemInfo<(typeof TUTORIAL_LIST_DATA)[number]> & {
   isActive: boolean;
@@ -13,23 +12,9 @@ type Props = CarouselRenderItemInfo<(typeof TUTORIAL_LIST_DATA)[number]> & {
 const TutorialListItem = ({ item, isActive }: Props) => {
   const { title, description, video } = item;
 
-  const videoPlayer = useVideoPlayer(video, (player) => {
-    player.loop = true;
-    player.muted = true;
-  });
-
-  useEffect(() => {
-    if (isActive) {
-      videoPlayer.play();
-    } else {
-      videoPlayer.pause();
-      videoPlayer.currentTime = 0;
-    }
-  }, [videoPlayer, isActive]);
-
   return (
     <Slide>
-      <SlideVideo player={videoPlayer} contentFit="contain" nativeControls={false} />
+      {isActive ? <TutorialVideoPlayer source={video} /> : <TutorialVideoPlaceholder />}
       <TextContainer>
         <StyledMiddleTitle color="title">{title}</StyledMiddleTitle>
         <StyledBody2 color="sub1">{description}</StyledBody2>
@@ -47,11 +32,10 @@ const Slide = styled.View`
   background-color: ${COLOR.background};
 `;
 
-const SlideVideo = styled(VideoView)`
+const TutorialVideoPlaceholder = styled.View`
   flex: 1;
   width: 100%;
   height: 90%;
-  background-color: ${COLOR.background};
 `;
 
 const TextContainer = styled.View`

--- a/src/features/tutorial/components/TutorialVideoPlayer.tsx
+++ b/src/features/tutorial/components/TutorialVideoPlayer.tsx
@@ -1,0 +1,39 @@
+import { COLOR } from '@/src/constants/theme';
+import { useVideoPlayer, VideoView, type VideoSource } from 'expo-video';
+import { useEffect } from 'react';
+import styled from 'styled-components/native';
+
+type Props = {
+  source: VideoSource;
+};
+
+const TutorialVideoPlayer = ({ source }: Props) => {
+  console.log('[TutorialVideoPlayer] render, source:', source);
+
+  const videoPlayer = useVideoPlayer(source, (player) => {
+    player.loop = true;
+    player.muted = true;
+    player.bufferOptions = {
+      preferredForwardBufferDuration: 0,
+    };
+  });
+
+  useEffect(() => {
+    videoPlayer.play();
+
+    return () => {
+      videoPlayer.release();
+    };
+  }, [videoPlayer]);
+
+  return <SlideVideo player={videoPlayer} contentFit="contain" nativeControls={false} />;
+};
+
+export default TutorialVideoPlayer;
+
+const SlideVideo = styled(VideoView)`
+  flex: 1;
+  width: 100%;
+  height: 90%;
+  background-color: ${COLOR.background};
+`;


### PR DESCRIPTION
## 👀 관련 이슈

close #243 

<img width="2666" height="314" alt="Image" src="https://github.com/user-attachments/assets/a271289b-24e3-4d46-8e92-78942834a054" />

최근 발생하고 있는 Android Out Of Memory 크래시 이슈를 대응합니다.

주요 원인은 "튜토리얼 페이지"에서 한 번에 모든 영상을 메모리로 불러오고, release 처리하지 않고 있는 점입니다.

## ✨ 작업한 내용


- [x] `TutorialListItem`에서 isActive가 true인 경우만 useVideoPlayer를 호출하기 위해 `TutorialVideoPlayer` 컴포넌트 추가
- [x] `TutorialVideoPlayer`는 mount되면 video를 play하고, unmount되면 release해서 메모리를 확보하도록 수정
  - 최종적으로 현재 보이는 페이지에 대해서만 video가 메모리에 올라가도록 개선
- [x] video가 로드되는 동안 발생하는 Layout shift를 막기 위해 `TutorialVideoPlayer`와 동일한 크기의 `TutorialVideoPlaceholder` View 추가

## 📷스크린샷 / 영상

> 작업 결과물을 스크린샷, 영상 등으로 확인할 수 있게 제공해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

* **개선 사항**
  * 튜토리얼 비디오 플레이어 구성 최적화: 새로운 전용 비디오 플레이어 컴포넌트로 리팩토링하여 활성 상태에서만 비디오를 렌더링하고 루핑, 자동 음소거, 버퍼 설정 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->