### PR TITLE
[main] Admob 배너 도입

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -105,6 +105,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         url: 'https://sentry.io/',
       },
     ],
+    [
+      'react-native-google-mobile-ads',
+      {
+        androidAppId: process.env.AD_MOB_ANDROID_APP_ID,
+        iosAppId: process.env.AD_MOB_IOS_APP_ID,
+      },
+    ],
   ],
   experiments: {
     typedRoutes: true,

--- a/app.config.ts
+++ b/app.config.ts
@@ -112,6 +112,12 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         iosAppId: process.env.AD_MOB_IOS_APP_ID,
       },
     ],
+    [
+      'expo-tracking-transparency',
+      {
+        userTrackingPermission: '맞춤형 광고 제공을 위해 추적 권한을 요청합니다.',
+      },
+    ],
   ],
   experiments: {
     typedRoutes: true,

--- a/app.config.ts
+++ b/app.config.ts
@@ -6,7 +6,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: 'Melissa',
   slug: 'melissa',
   owner: 'teammelissa7',
-  version: '1.3.3',
+  version: '1.3.4',
   orientation: 'portrait',
   icon: './assets/images/icon.png',
   scheme: 'myapp',

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "expo-status-bar": "~55.0.4",
     "expo-symbols": "~55.0.5",
     "expo-system-ui": "~55.0.11",
+    "expo-tracking-transparency": "~55.0.14",
     "expo-updates": "~55.0.16",
     "expo-video": "~55.0.11",
     "expo-web-browser": "~55.0.10",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-native-calendars": "1.1308.1",
     "react-native-date-picker": "^5.0.13",
     "react-native-gesture-handler": "~2.30.1",
+    "react-native-google-mobile-ads": "^16.3.3",
     "react-native-keyboard-controller": "^1.20.7",
     "react-native-mmkv": "^3.3.3",
     "react-native-reanimated": "~4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       expo-system-ui:
         specifier: ~55.0.11
         version: 55.0.11(expo@55.0.9)(react-native-web@0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))
+      expo-tracking-transparency:
+        specifier: ~55.0.14
+        version: 55.0.14(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))
       expo-updates:
         specifier: ~55.0.16
         version: 55.0.16(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
@@ -3670,6 +3673,12 @@ packages:
     peerDependenciesMeta:
       react-native-web:
         optional: true
+
+  expo-tracking-transparency@55.0.14:
+    resolution: {integrity: sha512-QRIuJXmNiYUJfZQTzV3BWfbbs9XtZPaI1YubOh7NcWziyh0kA/+WioNMYU0n7Y4l1YAmR3EKQhCi6hde5Gz1lw==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
 
   expo-updates-interface@55.1.3:
     resolution: {integrity: sha512-UVVIiZqymQZJL+o/jh65kXOI97xdkbqBJJM0LMabaPMNLFnc6/WvOMOzmQs7SPyKb8+0PeBaFd7tj5DzF6JeQg==}
@@ -10973,6 +10982,11 @@ snapshots:
       react-native-web: 0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
+
+  expo-tracking-transparency@55.0.14(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)):
+    dependencies:
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.7)(expo-router@55.0.8)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
 
   expo-updates-interface@55.1.3(expo@55.0.9):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.30.1
         version: 2.30.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      react-native-google-mobile-ads:
+        specifier: ^16.3.3
+        version: 16.3.3(expo@55.0.9)(react@19.2.0)
       react-native-keyboard-controller:
         specifier: ^1.20.7
         version: 1.20.7(react-native-reanimated@4.2.1(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -1254,6 +1257,9 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@iabtcf/core@1.5.6':
+    resolution: {integrity: sha512-u2q9thI9vLurYZdGtyJsDYOqoeLc4EgQsYGSc+UVibYII61B/ENJPZS6eFlML1F0hSoTR/goptpo5nGRDkKd2w==}
 
   '@ibm-cloud/openapi-ruleset-utilities@1.9.0':
     resolution: {integrity: sha512-AoFbSarOqFBYH+1TZ9Ahkm2IWYSi5v0pBk88fpV+5b3qGJukypX8PwvCWADjuyIccKg48/F73a6hTTkBzDQ2UA==}
@@ -3098,6 +3104,10 @@ packages:
   dependency-graph@0.11.0:
     resolution: {integrity: sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==}
     engines: {node: '>= 0.6.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -5467,6 +5477,14 @@ packages:
       react: '*'
       react-native: '*'
 
+  react-native-google-mobile-ads@16.3.3:
+    resolution: {integrity: sha512-7AFdH3sUyAvwJc7dNJ7sxqfKJVWcdPRx5HdfWQOEsJTp9y+wOJ2V6cnLNkgBjZQG/W/ODZQDq4pKg51zBju2eg==}
+    peerDependencies:
+      expo: '>=47.0.0'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
   react-native-is-edge-to-edge@1.2.1:
     resolution: {integrity: sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==}
     peerDependencies:
@@ -6340,6 +6358,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-deep-compare-effect@1.8.1:
+    resolution: {integrity: sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==}
+    engines: {node: '>=10', npm: '>=6'}
+    peerDependencies:
+      react: '>=16.13'
 
   use-latest-callback@0.2.6:
     resolution: {integrity: sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==}
@@ -7900,6 +7924,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@iabtcf/core@1.5.6': {}
 
   '@ibm-cloud/openapi-ruleset-utilities@1.9.0': {}
 
@@ -10187,6 +10213,8 @@ snapshots:
   depd@2.0.0: {}
 
   dependency-graph@0.11.0: {}
+
+  dequal@2.0.3: {}
 
   destroy@1.2.0: {}
 
@@ -13253,6 +13281,15 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
 
+  react-native-google-mobile-ads@16.3.3(expo@55.0.9)(react@19.2.0):
+    dependencies:
+      '@iabtcf/core': 1.5.6
+      use-deep-compare-effect: 1.8.1(react@19.2.0)
+    optionalDependencies:
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@55.0.7)(expo-router@55.0.8)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - react
+
   react-native-is-edge-to-edge@1.2.1(react-native@0.83.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
@@ -14229,6 +14266,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  use-deep-compare-effect@1.8.1(react@19.2.0):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      dequal: 2.0.3
+      react: 19.2.0
 
   use-latest-callback@0.2.6(react@19.2.0):
     dependencies:

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,4 +1,5 @@
 import queryClient from '@/src/libs/queryClient';
+import { AdsProvider } from '@/src/modules/ads';
 import { ModalsProvider } from '@/src/modules/modal';
 import { NotificationProvider } from '@/src/modules/notification';
 import { SentryProvider } from '@/src/modules/sentry';
@@ -36,18 +37,20 @@ export default function RootLayout() {
   return (
     <SentryProvider>
       <NotificationProvider>
-        <QueryClientProvider client={queryClient}>
-          <KeyboardProvider>
-            <GestureHandlerRootView>
-              <ModalsProvider>
-                <StatusBar style="dark" />
-                <Slot />
-                <ToastsRoot />
-                <PortalHost />
-              </ModalsProvider>
-            </GestureHandlerRootView>
-          </KeyboardProvider>
-        </QueryClientProvider>
+        <AdsProvider>
+          <QueryClientProvider client={queryClient}>
+            <KeyboardProvider>
+              <GestureHandlerRootView>
+                <ModalsProvider>
+                  <StatusBar style="dark" />
+                  <Slot />
+                  <ToastsRoot />
+                  <PortalHost />
+                </ModalsProvider>
+              </GestureHandlerRootView>
+            </KeyboardProvider>
+          </QueryClientProvider>
+        </AdsProvider>
       </NotificationProvider>
     </SentryProvider>
   );

--- a/src/features/characters/components/ActionButtons.tsx
+++ b/src/features/characters/components/ActionButtons.tsx
@@ -24,7 +24,6 @@ export default ActionButtons;
 const ButtonWrapper = styled.View`
   width: 100%;
   align-items: center;
-  margin-top: auto;
   gap: 15px;
   padding-bottom: 15px;
 `;

--- a/src/features/characters/containers/CharactersContainer.tsx
+++ b/src/features/characters/containers/CharactersContainer.tsx
@@ -55,7 +55,7 @@ const CharactersContainer = () => {
         onSelectChange={handleAiProfileIdChange}
         onCharacterClick={handleCreateThreadAndNavigate}
       />
-      <AdsBanner unitId="" style={{ alignItems: 'center' }} />
+      <AdsBanner style={{ alignItems: 'center' }} />
       <ActionButtons onChattingClick={handleCreateThreadAndNavigate} onManualDiaryClick={handleManualDiaryClick} />
     </SafeView>
   );

--- a/src/features/characters/containers/CharactersContainer.tsx
+++ b/src/features/characters/containers/CharactersContainer.tsx
@@ -1,6 +1,7 @@
 import { useCreateThread } from '@/src/apis/_generated/serverAPI';
 import { COLOR } from '@/src/constants/theme';
 import { LargeTitle } from '@/src/core/Txt';
+import { AdsBanner } from '@/src/modules/ads';
 import type { CharacterId } from '@/src/modules/character';
 import { toast } from '@/src/modules/toast';
 import { useRouter } from 'expo-router';
@@ -54,6 +55,7 @@ const CharactersContainer = () => {
         onSelectChange={handleAiProfileIdChange}
         onCharacterClick={handleCreateThreadAndNavigate}
       />
+      <AdsBanner unitId="" style={{ alignItems: 'center' }} />
       <ActionButtons onChattingClick={handleCreateThreadAndNavigate} onManualDiaryClick={handleManualDiaryClick} />
     </SafeView>
   );

--- a/src/features/characters/containers/CharactersContainer.tsx
+++ b/src/features/characters/containers/CharactersContainer.tsx
@@ -55,8 +55,10 @@ const CharactersContainer = () => {
         onSelectChange={handleAiProfileIdChange}
         onCharacterClick={handleCreateThreadAndNavigate}
       />
-      <AdsBanner style={{ alignItems: 'center' }} />
-      <ActionButtons onChattingClick={handleCreateThreadAndNavigate} onManualDiaryClick={handleManualDiaryClick} />
+      <BottomSection>
+        <AdsBanner style={{ alignItems: 'center' }} />
+        <ActionButtons onChattingClick={handleCreateThreadAndNavigate} onManualDiaryClick={handleManualDiaryClick} />
+      </BottomSection>
     </SafeView>
   );
 };
@@ -67,9 +69,14 @@ const SafeView = styled(SafeAreaView)`
   flex: 1;
   background-color: ${COLOR.background};
   padding: 0 18px;
+  gap: 20px;
+`;
+
+const BottomSection = styled.View`
+  gap: 20px;
+  margin-top: auto;
 `;
 
 const StyledLargeTitle = styled(LargeTitle)`
   text-align: center;
-  margin-bottom: 40px;
 `;

--- a/src/features/home/containers/FeedContainer.tsx
+++ b/src/features/home/containers/FeedContainer.tsx
@@ -1,5 +1,6 @@
 import { useGetFeedInfinite } from '@/src/apis/_generated/serverAPI';
 import { COLOR } from '@/src/constants/theme';
+import { AdsBanner } from '@/src/modules/ads';
 import styled from 'styled-components/native';
 import FeedList from '../components/feed/FeedList';
 import HomeHeader from '../components/header/HomeHeader';
@@ -28,6 +29,7 @@ const FeedContainer = () => {
   return (
     <Wrapper>
       <HomeHeader />
+      <AdsBanner unitId="" style={{ alignItems: 'center' }} />
       <FeedList
         monthData={calendarMonthData ?? []}
         isPending={isPending}
@@ -43,6 +45,6 @@ export default FeedContainer;
 const Wrapper = styled.View`
   flex: 1;
   padding: 0 15px;
-  gap: 25px;
+  gap: 15px;
   background-color: ${COLOR.background};
 `;

--- a/src/features/home/containers/FeedContainer.tsx
+++ b/src/features/home/containers/FeedContainer.tsx
@@ -29,7 +29,7 @@ const FeedContainer = () => {
   return (
     <Wrapper>
       <HomeHeader />
-      <AdsBanner unitId="" style={{ alignItems: 'center' }} />
+      <AdsBanner style={{ alignItems: 'center' }} />
       <FeedList
         monthData={calendarMonthData ?? []}
         isPending={isPending}

--- a/src/features/setting/containers/SettingContainer.tsx
+++ b/src/features/setting/containers/SettingContainer.tsx
@@ -1,5 +1,6 @@
 import { useGetUserSetting } from '@/src/apis/_generated/serverAPI';
 import { COLOR } from '@/src/constants/theme';
+import { AdsBanner } from '@/src/modules/ads';
 import { useRouter } from 'expo-router';
 import { Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -71,6 +72,7 @@ export default function SettingContainer() {
         onFeedbackClick={handleFeedbackClick}
       />
       <AccountActions onLogout={handleLogout} onDeleteAccount={handleDeleteAccount} />
+      <AdsBanner unitId="" style={{ alignItems: 'center' }} />
     </SafeView>
   );
 }

--- a/src/features/setting/containers/SettingContainer.tsx
+++ b/src/features/setting/containers/SettingContainer.tsx
@@ -72,7 +72,7 @@ export default function SettingContainer() {
         onFeedbackClick={handleFeedbackClick}
       />
       <AccountActions onLogout={handleLogout} onDeleteAccount={handleDeleteAccount} />
-      <AdsBanner unitId="" style={{ alignItems: 'center' }} />
+      <AdsBanner style={{ alignItems: 'center' }} />
     </SafeView>
   );
 }

--- a/src/features/write-diary/containers/EditDiaryContainer.tsx
+++ b/src/features/write-diary/containers/EditDiaryContainer.tsx
@@ -93,7 +93,7 @@ const EditDiaryContainer = () => {
             <DiaryHashtagInput value={hashtag2} onValueChange={setHashtag2} placeholder="태그2" />
           </HashtagWrapper>
         </ContentWrapper>
-        <AdsBanner unitId="" style={{ alignItems: 'center' }} />
+        <AdsBanner style={{ alignItems: 'center' }} />
         <ButtonWrapper>
           <PrimaryButton size="large" disabled={!isFormValid} onPress={handleSubmitClick}>
             수정 완료

--- a/src/features/write-diary/containers/EditDiaryContainer.tsx
+++ b/src/features/write-diary/containers/EditDiaryContainer.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/src/apis/_generated/serverAPI';
 import { COLOR } from '@/src/constants/theme';
 import { PrimaryButton } from '@/src/core/Button';
+import { AdsBanner } from '@/src/modules/ads';
 import { toast } from '@/src/modules/toast';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
@@ -92,6 +93,7 @@ const EditDiaryContainer = () => {
             <DiaryHashtagInput value={hashtag2} onValueChange={setHashtag2} placeholder="태그2" />
           </HashtagWrapper>
         </ContentWrapper>
+        <AdsBanner unitId="" style={{ alignItems: 'center' }} />
         <ButtonWrapper>
           <PrimaryButton size="large" disabled={!isFormValid} onPress={handleSubmitClick}>
             수정 완료
@@ -108,6 +110,7 @@ const SafeView = styled(SafeAreaView)`
   flex: 1;
   background-color: ${COLOR.background};
   padding: 0 18px;
+  gap: 24px;
 `;
 
 const LoadingWrapper = styled(View)`

--- a/src/features/write-diary/containers/WriteDiaryContainer.tsx
+++ b/src/features/write-diary/containers/WriteDiaryContainer.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/src/apis/_generated/serverAPI';
 import { COLOR } from '@/src/constants/theme';
 import { PrimaryButton } from '@/src/core/Button';
+import { AdsBanner } from '@/src/modules/ads';
 import { toast } from '@/src/modules/toast';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'expo-router';
@@ -62,6 +63,7 @@ const WriteDiaryContainer = () => {
           <DiaryTitleInput value={title} onValueChange={setTitle} />
           <DiaryContentInput value={content} onValueChange={setContent} />
         </ContentWrapper>
+        <AdsBanner unitId="" style={{ alignItems: 'center' }} />
         <ButtonWrapper>
           <PrimaryButton
             size="large"
@@ -82,6 +84,7 @@ const SafeView = styled(SafeAreaView)`
   flex: 1;
   background-color: ${COLOR.background};
   padding: 0 18px;
+  gap: 24px;
 `;
 
 const ContentWrapper = styled.View`

--- a/src/features/write-diary/containers/WriteDiaryContainer.tsx
+++ b/src/features/write-diary/containers/WriteDiaryContainer.tsx
@@ -63,7 +63,7 @@ const WriteDiaryContainer = () => {
           <DiaryTitleInput value={title} onValueChange={setTitle} />
           <DiaryContentInput value={content} onValueChange={setContent} />
         </ContentWrapper>
-        <AdsBanner unitId="" style={{ alignItems: 'center' }} />
+        <AdsBanner style={{ alignItems: 'center' }} />
         <ButtonWrapper>
           <PrimaryButton
             size="large"

--- a/src/modules/ads/components/AdsBanner.tsx
+++ b/src/modules/ads/components/AdsBanner.tsx
@@ -1,0 +1,28 @@
+import { useRef } from 'react';
+import { Platform } from 'react-native';
+import { BannerAd, BannerAdSize, TestIds, useForeground } from 'react-native-google-mobile-ads';
+import { useAdsContext } from '../hooks/useAdsContext';
+
+type Props = {
+  unitId: string;
+  size?: BannerAdSize;
+};
+
+export const AdsBanner = ({ unitId, size }: Props) => {
+  const adBannerRef = useRef<BannerAd>(null);
+  const { initialized } = useAdsContext();
+
+  const adUnitId = __DEV__ ? TestIds.ADAPTIVE_BANNER : unitId;
+  const adSize = size ?? BannerAdSize.LARGE_ANCHORED_ADAPTIVE_BANNER;
+
+  // IOS에 한해 background -> foreground 복귀 시 광고 reload
+  useForeground(() => {
+    if (Platform.OS === 'ios') {
+      adBannerRef.current?.load();
+    }
+  });
+
+  if (!initialized) return null;
+
+  return <BannerAd ref={adBannerRef} unitId={adUnitId} size={adSize} />;
+};

--- a/src/modules/ads/components/AdsBanner.tsx
+++ b/src/modules/ads/components/AdsBanner.tsx
@@ -1,18 +1,18 @@
 import { useRef } from 'react';
 import { Platform, View, type ViewProps } from 'react-native';
 import { BannerAd, BannerAdSize, TestIds, useForeground } from 'react-native-google-mobile-ads';
+import { BANNER_UNIT_ID } from '../constants/adsUnitId';
 import { useAdsContext } from '../hooks/useAdsContext';
 
 type Props = ViewProps & {
-  unitId: string;
   size?: BannerAdSize;
 };
 
-export const AdsBanner = ({ unitId, size, ...props }: Props) => {
+export const AdsBanner = ({ size, ...props }: Props) => {
   const adBannerRef = useRef<BannerAd>(null);
   const { initialized } = useAdsContext();
 
-  const adUnitId = __DEV__ ? TestIds.ADAPTIVE_BANNER : unitId;
+  const adUnitId = __DEV__ ? TestIds.ADAPTIVE_BANNER : BANNER_UNIT_ID;
   const adSize = size ?? BannerAdSize.BANNER;
 
   // IOS에 한해 background -> foreground 복귀 시 광고 reload

--- a/src/modules/ads/components/AdsBanner.tsx
+++ b/src/modules/ads/components/AdsBanner.tsx
@@ -1,19 +1,19 @@
 import { useRef } from 'react';
-import { Platform } from 'react-native';
+import { Platform, View, type ViewProps } from 'react-native';
 import { BannerAd, BannerAdSize, TestIds, useForeground } from 'react-native-google-mobile-ads';
 import { useAdsContext } from '../hooks/useAdsContext';
 
-type Props = {
+type Props = ViewProps & {
   unitId: string;
   size?: BannerAdSize;
 };
 
-export const AdsBanner = ({ unitId, size }: Props) => {
+export const AdsBanner = ({ unitId, size, ...props }: Props) => {
   const adBannerRef = useRef<BannerAd>(null);
   const { initialized } = useAdsContext();
 
   const adUnitId = __DEV__ ? TestIds.ADAPTIVE_BANNER : unitId;
-  const adSize = size ?? BannerAdSize.LARGE_ANCHORED_ADAPTIVE_BANNER;
+  const adSize = size ?? BannerAdSize.BANNER;
 
   // IOS에 한해 background -> foreground 복귀 시 광고 reload
   useForeground(() => {
@@ -24,5 +24,9 @@ export const AdsBanner = ({ unitId, size }: Props) => {
 
   if (!initialized) return null;
 
-  return <BannerAd ref={adBannerRef} unitId={adUnitId} size={adSize} />;
+  return (
+    <View {...props}>
+      <BannerAd ref={adBannerRef} unitId={adUnitId} size={adSize} />
+    </View>
+  );
 };

--- a/src/modules/ads/components/AdsBanner.tsx
+++ b/src/modules/ads/components/AdsBanner.tsx
@@ -12,7 +12,7 @@ export const AdsBanner = ({ size, ...props }: Props) => {
   const adBannerRef = useRef<BannerAd>(null);
   const { initialized } = useAdsContext();
 
-  const adUnitId = __DEV__ ? TestIds.ADAPTIVE_BANNER : BANNER_UNIT_ID;
+  const adUnitId = __DEV__ ? TestIds.BANNER : BANNER_UNIT_ID;
   const adSize = size ?? BannerAdSize.BANNER;
 
   // IOS에 한해 background -> foreground 복귀 시 광고 reload

--- a/src/modules/ads/constants/adsUnitId.ts
+++ b/src/modules/ads/constants/adsUnitId.ts
@@ -1,0 +1,6 @@
+import { Platform } from 'react-native';
+
+const ANDROID_BANNER_UNIT_ID = process.env.EXPO_PUBLIC_AD_MOB_ANDROID_BANNER_UNIT_ID ?? '';
+const IOS_BANNER_UNIT_ID = process.env.EXPO_PUBLIC_AD_MOB_IOS_BANNER_UNIT_ID ?? '';
+
+export const BANNER_UNIT_ID = Platform.OS === 'android' ? ANDROID_BANNER_UNIT_ID : IOS_BANNER_UNIT_ID;

--- a/src/modules/ads/hooks/useAdsContext.ts
+++ b/src/modules/ads/hooks/useAdsContext.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { AdsContext } from '../providers/AdsProvider';
+
+export const useAdsContext = () => {
+  const context = useContext(AdsContext);
+
+  if (!context) {
+    throw new Error('<AdsProvider> 내에서만 사용 가능합니다');
+  }
+
+  return context;
+};

--- a/src/modules/ads/index.ts
+++ b/src/modules/ads/index.ts
@@ -1,0 +1,2 @@
+export { AdsBanner } from './components/AdsBanner';
+export { AdsProvider } from './providers/AdsProvider';

--- a/src/modules/ads/providers/AdsProvider.tsx
+++ b/src/modules/ads/providers/AdsProvider.tsx
@@ -1,0 +1,41 @@
+import * as Sentry from '@sentry/react-native';
+import {
+  getTrackingPermissionsAsync,
+  PermissionStatus,
+  requestTrackingPermissionsAsync,
+} from 'expo-tracking-transparency';
+import { createContext, useEffect, useState, type PropsWithChildren } from 'react';
+import mobileAds from 'react-native-google-mobile-ads';
+
+type ContextValue = {
+  initialized: boolean;
+};
+
+export const AdsContext = createContext<ContextValue | null>(null);
+
+export const AdsProvider = ({ children }: PropsWithChildren) => {
+  const [initialized, setInitialized] = useState<boolean>(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const { status } = await getTrackingPermissionsAsync();
+
+        if (status === PermissionStatus.UNDETERMINED) {
+          await requestTrackingPermissionsAsync();
+        }
+
+        await mobileAds().initialize();
+        setInitialized(true);
+      } catch (e) {
+        Sentry.captureException(e, {
+          tags: {
+            module: 'ads',
+          },
+        });
+      }
+    })();
+  }, []);
+
+  return <AdsContext.Provider value={{ initialized }}>{children}</AdsContext.Provider>;
+};


### PR DESCRIPTION
> [!IMPORTANT]
> AdMob 계정 및 광고 수익은 전적으로 PM 소유/관리 범위입니다.
> 구현 담당자에게 수익은 전혀 귀속되지 않으며, 광고는 서버/API 비용 보전을 위해 도입합니다.

## 👀 관련 이슈

close #247

## ✨ 작업한 내용

- [x] `react-native-google-mobile-ads`, `expo-tracking-transparency` 의존성/Expo 설정 추가 
- [x] Android/iOS AdMob App ID 등록
- [x] 광고 초기화/ATT 권한 요청을 담당하는 `AdsProvider` 추가
- [x] 광고 초기화 실패 시 Sentry로 에러 수집
- [x] 배너 광고 공통 컴포넌트(`AdsBanner`) 및 광고 Unit ID 관리 로직 구현
- [x] 피드, 설정, 캐릭터 선택, 일기 작성, 일기 수정 화면에 배너 광고 배치

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 앱 내 여러 화면에 광고가 추가되었습니다.
  * 사용자 추적 투명성 권한 요청이 한국어로 표시됩니다.

* **기타**
  * 앱 버전이 1.3.4로 업데이트되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-Melissa/melissa-FE/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->