### PR TITLE
[main] Github Actions 빌드 실패 대응

### DIFF
--- a/.github/workflows/eas-build-submit.yaml
+++ b/.github/workflows/eas-build-submit.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'pnpm'
 
       - name: 🏗 Setup EAS

--- a/.github/workflows/eas-build-submit.yaml
+++ b/.github/workflows/eas-build-submit.yaml
@@ -6,12 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
-
-      - name: 📦 Install pnpm
-        run: npm install -g pnpm
+          cache: 'pnpm'
 
       - name: 🏗 Setup EAS
         uses: expo/expo-github-action@v8

--- a/.github/workflows/eas-update.yaml
+++ b/.github/workflows/eas-update.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'pnpm'
 
       - name: 🏗 Setup EAS

--- a/.github/workflows/eas-update.yaml
+++ b/.github/workflows/eas-update.yaml
@@ -6,12 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x
-
-      - name: 📦 Install pnpm
-        run: npm install -g pnpm
+          cache: 'pnpm'
 
       - name: 🏗 Setup EAS
         uses: expo/expo-github-action@v8

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "melissa-fe",
   "main": "expo-router/entry",
   "version": "1.0.0",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",


### PR DESCRIPTION
## 👀 관련 이슈

close #247 

## ✨ 작업한 내용

- [x] `package.json`에 pnpm version 명시
- [x] Github Actions에서 `npm install -g pnpm` 대신 `pnpm/action-setup@v4` 사용하도록 변경
- [x] node version 24 LTS로 교체

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Node.js 런타임 버전을 22.x에서 24.x로 업그레이드했습니다.
  * pnpm 패키지 매니저 설정을 개선하여 빌드 및 업데이트 워크플로우 최적화했습니다.
  * 패키지 매니저 버전 명시 정보를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-Melissa/melissa-FE/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->